### PR TITLE
chore: align with Obsidian community plugin scorecard

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,11 @@ on:
     tags:
       - '*.*.*'
 
+permissions:
+  contents: write
+  id-token: write
+  attestations: write
+
 jobs:
   build-and-release:
     runs-on: ubuntu-latest
@@ -18,7 +23,15 @@ jobs:
       - run: node scripts/assert-versions.cjs
       - run: npm run test
       - run: npm run build
-      - run: npm run release:zip
+
+      # Build provenance attestation for release artifacts (per Obsidian scorecard recommendation)
+      - name: Attest release artifacts
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: |
+            main.js
+            manifest.json
+            styles.css
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
@@ -29,4 +42,3 @@ jobs:
             main.js
             manifest.json
             styles.css
-            snipsidian-*.zip

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -55,6 +55,16 @@ export default [
       // UI sentence case with custom options
       // Disabled - too many false positives with validation messages, button texts, etc.
       'obsidianmd/ui/sentence-case': 'off',
+
+      // Match the Obsidian scorecard scanner's strict no-unused-vars policy:
+      // every declared argument must be used (or prefixed with `_`).
+      '@typescript-eslint/no-unused-vars': ['error', {
+        args: 'all',
+        argsIgnorePattern: '^_',
+        varsIgnorePattern: '^_',
+        caughtErrors: 'all',
+        caughtErrorsIgnorePattern: '^_',
+      }],
     },
   },
   

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "id": "snipsidian",
   "version": "1.0.5",
   "minAppVersion": "1.5.0",
-  "description": "Snipsy adds hotstrings/text expansion to the editor — folders, bulk editing, and Espanso-compatible packs.",
+  "description": "Hotstrings and snippet management for the editor with folders, bulk editing, and Espanso-compatible packs.",
   "author": "Dimagious",
   "authorUrl": "https://github.com/Dimagious",
   "fundingUrl": "https://buymeacoffee.com/dimagious",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,17 +9,15 @@
             "version": "1.0.5",
             "license": "MIT",
             "dependencies": {
-                "js-yaml": "^4.1.0"
+                "yaml": "^2.9.0"
             },
             "devDependencies": {
                 "@eslint/js": "^9.39.1",
                 "@microsoft/eslint-plugin-sdl": "^1.1.0",
-                "@types/js-yaml": "^4.0.9",
                 "@types/node": "^20.12.12",
                 "@vitest/coverage-v8": "^3.2.4",
-                "esbuild": "^0.23.0",
+                "esbuild": "^0.28.0",
                 "eslint": "^9.39.1",
-                "eslint-plugin-import": "^2.32.0",
                 "eslint-plugin-obsidianmd": "^0.1.7",
                 "jsdom": "^26.1.0",
                 "obsidian": "^1.5.0",
@@ -258,9 +256,9 @@
             }
         },
         "node_modules/@esbuild/aix-ppc64": {
-            "version": "0.23.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.23.1.tgz",
-            "integrity": "sha512-6VhYk1diRqrhBAqpJEdjASR/+WVRtfjpqKuNw11cLiaWpAT/Uu+nokB+UJnevzy/P9C/ty6AOe0dwueMrGh/iQ==",
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+            "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
             "cpu": [
                 "ppc64"
             ],
@@ -275,9 +273,9 @@
             }
         },
         "node_modules/@esbuild/android-arm": {
-            "version": "0.23.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.23.1.tgz",
-            "integrity": "sha512-uz6/tEy2IFm9RYOyvKl88zdzZfwEfKZmnX9Cj1BHjeSGNuGLuMD1kR8y5bteYmwqKm1tj8m4cb/aKEorr6fHWQ==",
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+            "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
             "cpu": [
                 "arm"
             ],
@@ -292,9 +290,9 @@
             }
         },
         "node_modules/@esbuild/android-arm64": {
-            "version": "0.23.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.23.1.tgz",
-            "integrity": "sha512-xw50ipykXcLstLeWH7WRdQuysJqejuAGPd30vd1i5zSyKK3WE+ijzHmLKxdiCMtH1pHz78rOg0BKSYOSB/2Khw==",
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+            "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
             "cpu": [
                 "arm64"
             ],
@@ -309,9 +307,9 @@
             }
         },
         "node_modules/@esbuild/android-x64": {
-            "version": "0.23.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.23.1.tgz",
-            "integrity": "sha512-nlN9B69St9BwUoB+jkyU090bru8L0NA3yFvAd7k8dNsVH8bi9a8cUAUSEcEEgTp2z3dbEDGJGfP6VUnkQnlReg==",
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+            "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
             "cpu": [
                 "x64"
             ],
@@ -326,9 +324,9 @@
             }
         },
         "node_modules/@esbuild/darwin-arm64": {
-            "version": "0.23.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.23.1.tgz",
-            "integrity": "sha512-YsS2e3Wtgnw7Wq53XXBLcV6JhRsEq8hkfg91ESVadIrzr9wO6jJDMZnCQbHm1Guc5t/CdDiFSSfWP58FNuvT3Q==",
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
+            "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
             "cpu": [
                 "arm64"
             ],
@@ -343,9 +341,9 @@
             }
         },
         "node_modules/@esbuild/darwin-x64": {
-            "version": "0.23.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.23.1.tgz",
-            "integrity": "sha512-aClqdgTDVPSEGgoCS8QDG37Gu8yc9lTHNAQlsztQ6ENetKEO//b8y31MMu2ZaPbn4kVsIABzVLXYLhCGekGDqw==",
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+            "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
             "cpu": [
                 "x64"
             ],
@@ -360,9 +358,9 @@
             }
         },
         "node_modules/@esbuild/freebsd-arm64": {
-            "version": "0.23.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.23.1.tgz",
-            "integrity": "sha512-h1k6yS8/pN/NHlMl5+v4XPfikhJulk4G+tKGFIOwURBSFzE8bixw1ebjluLOjfwtLqY0kewfjLSrO6tN2MgIhA==",
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+            "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
             "cpu": [
                 "arm64"
             ],
@@ -377,9 +375,9 @@
             }
         },
         "node_modules/@esbuild/freebsd-x64": {
-            "version": "0.23.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.23.1.tgz",
-            "integrity": "sha512-lK1eJeyk1ZX8UklqFd/3A60UuZ/6UVfGT2LuGo3Wp4/z7eRTRYY+0xOu2kpClP+vMTi9wKOfXi2vjUpO1Ro76g==",
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+            "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
             "cpu": [
                 "x64"
             ],
@@ -394,9 +392,9 @@
             }
         },
         "node_modules/@esbuild/linux-arm": {
-            "version": "0.23.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.23.1.tgz",
-            "integrity": "sha512-CXXkzgn+dXAPs3WBwE+Kvnrf4WECwBdfjfeYHpMeVxWE0EceB6vhWGShs6wi0IYEqMSIzdOF1XjQ/Mkm5d7ZdQ==",
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+            "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
             "cpu": [
                 "arm"
             ],
@@ -411,9 +409,9 @@
             }
         },
         "node_modules/@esbuild/linux-arm64": {
-            "version": "0.23.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.23.1.tgz",
-            "integrity": "sha512-/93bf2yxencYDnItMYV/v116zff6UyTjo4EtEQjUBeGiVpMmffDNUyD9UN2zV+V3LRV3/on4xdZ26NKzn6754g==",
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+            "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
             "cpu": [
                 "arm64"
             ],
@@ -428,9 +426,9 @@
             }
         },
         "node_modules/@esbuild/linux-ia32": {
-            "version": "0.23.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.23.1.tgz",
-            "integrity": "sha512-VTN4EuOHwXEkXzX5nTvVY4s7E/Krz7COC8xkftbbKRYAl96vPiUssGkeMELQMOnLOJ8k3BY1+ZY52tttZnHcXQ==",
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+            "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
             "cpu": [
                 "ia32"
             ],
@@ -445,9 +443,9 @@
             }
         },
         "node_modules/@esbuild/linux-loong64": {
-            "version": "0.23.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.23.1.tgz",
-            "integrity": "sha512-Vx09LzEoBa5zDnieH8LSMRToj7ir/Jeq0Gu6qJ/1GcBq9GkfoEAoXvLiW1U9J1qE/Y/Oyaq33w5p2ZWrNNHNEw==",
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+            "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
             "cpu": [
                 "loong64"
             ],
@@ -462,9 +460,9 @@
             }
         },
         "node_modules/@esbuild/linux-mips64el": {
-            "version": "0.23.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.23.1.tgz",
-            "integrity": "sha512-nrFzzMQ7W4WRLNUOU5dlWAqa6yVeI0P78WKGUo7lg2HShq/yx+UYkeNSE0SSfSure0SqgnsxPvmAUu/vu0E+3Q==",
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+            "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
             "cpu": [
                 "mips64el"
             ],
@@ -479,9 +477,9 @@
             }
         },
         "node_modules/@esbuild/linux-ppc64": {
-            "version": "0.23.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.23.1.tgz",
-            "integrity": "sha512-dKN8fgVqd0vUIjxuJI6P/9SSSe/mB9rvA98CSH2sJnlZ/OCZWO1DJvxj8jvKTfYUdGfcq2dDxoKaC6bHuTlgcw==",
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+            "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
             "cpu": [
                 "ppc64"
             ],
@@ -496,9 +494,9 @@
             }
         },
         "node_modules/@esbuild/linux-riscv64": {
-            "version": "0.23.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.23.1.tgz",
-            "integrity": "sha512-5AV4Pzp80fhHL83JM6LoA6pTQVWgB1HovMBsLQ9OZWLDqVY8MVobBXNSmAJi//Csh6tcY7e7Lny2Hg1tElMjIA==",
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+            "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
             "cpu": [
                 "riscv64"
             ],
@@ -513,9 +511,9 @@
             }
         },
         "node_modules/@esbuild/linux-s390x": {
-            "version": "0.23.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.23.1.tgz",
-            "integrity": "sha512-9ygs73tuFCe6f6m/Tb+9LtYxWR4c9yg7zjt2cYkjDbDpV/xVn+68cQxMXCjUpYwEkze2RcU/rMnfIXNRFmSoDw==",
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+            "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
             "cpu": [
                 "s390x"
             ],
@@ -530,9 +528,9 @@
             }
         },
         "node_modules/@esbuild/linux-x64": {
-            "version": "0.23.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.23.1.tgz",
-            "integrity": "sha512-EV6+ovTsEXCPAp58g2dD68LxoP/wK5pRvgy0J/HxPGB009omFPv3Yet0HiaqvrIrgPTBuC6wCH1LTOY91EO5hQ==",
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+            "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
             "cpu": [
                 "x64"
             ],
@@ -564,9 +562,9 @@
             }
         },
         "node_modules/@esbuild/netbsd-x64": {
-            "version": "0.23.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.23.1.tgz",
-            "integrity": "sha512-aevEkCNu7KlPRpYLjwmdcuNz6bDFiE7Z8XC4CPqExjTvrHugh28QzUXVOZtiYghciKUacNktqxdpymplil1beA==",
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+            "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
             "cpu": [
                 "x64"
             ],
@@ -581,9 +579,9 @@
             }
         },
         "node_modules/@esbuild/openbsd-arm64": {
-            "version": "0.23.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.23.1.tgz",
-            "integrity": "sha512-3x37szhLexNA4bXhLrCC/LImN/YtWis6WXr1VESlfVtVeoFJBRINPJ3f0a/6LV8zpikqoUg4hyXw0sFBt5Cr+Q==",
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+            "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
             "cpu": [
                 "arm64"
             ],
@@ -598,9 +596,9 @@
             }
         },
         "node_modules/@esbuild/openbsd-x64": {
-            "version": "0.23.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.23.1.tgz",
-            "integrity": "sha512-aY2gMmKmPhxfU+0EdnN+XNtGbjfQgwZj43k8G3fyrDM/UdZww6xrWxmDkuz2eCZchqVeABjV5BpildOrUbBTqA==",
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+            "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
             "cpu": [
                 "x64"
             ],
@@ -632,9 +630,9 @@
             }
         },
         "node_modules/@esbuild/sunos-x64": {
-            "version": "0.23.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.23.1.tgz",
-            "integrity": "sha512-RBRT2gqEl0IKQABT4XTj78tpk9v7ehp+mazn2HbUeZl1YMdaGAQqhapjGTCe7uw7y0frDi4gS0uHzhvpFuI1sA==",
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+            "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
             "cpu": [
                 "x64"
             ],
@@ -649,9 +647,9 @@
             }
         },
         "node_modules/@esbuild/win32-arm64": {
-            "version": "0.23.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.23.1.tgz",
-            "integrity": "sha512-4O+gPR5rEBe2FpKOVyiJ7wNDPA8nGzDuJ6gN4okSA1gEOYZ67N8JPk58tkWtdtPeLz7lBnY6I5L3jdsr3S+A6A==",
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+            "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
             "cpu": [
                 "arm64"
             ],
@@ -666,9 +664,9 @@
             }
         },
         "node_modules/@esbuild/win32-ia32": {
-            "version": "0.23.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.23.1.tgz",
-            "integrity": "sha512-BcaL0Vn6QwCwre3Y717nVHZbAa4UBEigzFm6VdsVdT/MbZ38xoj1X9HPkZhbmaBGUD1W8vxAfffbDe8bA6AKnQ==",
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+            "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
             "cpu": [
                 "ia32"
             ],
@@ -683,9 +681,9 @@
             }
         },
         "node_modules/@esbuild/win32-x64": {
-            "version": "0.23.1",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.23.1.tgz",
-            "integrity": "sha512-BHpFFeslkWrXWyUPnbKm+xYYVYruCinGcftSBaa8zoF9hZO4BcSCFUvHVTtzpIY6YzUnYtuEhZ+C9iEXjxnasg==",
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+            "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
             "cpu": [
                 "x64"
             ],
@@ -752,28 +750,6 @@
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             }
         },
-        "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-            "dev": true,
-            "dependencies": {
-                "balanced-match": "^1.0.0",
-                "concat-map": "0.0.1"
-            }
-        },
-        "node_modules/@eslint/config-array/node_modules/minimatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-            "dev": true,
-            "dependencies": {
-                "brace-expansion": "^1.1.7"
-            },
-            "engines": {
-                "node": "*"
-            }
-        },
         "node_modules/@eslint/config-helpers": {
             "version": "0.4.2",
             "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
@@ -821,27 +797,29 @@
                 "url": "https://opencollective.com/eslint"
             }
         },
-        "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+        "node_modules/@eslint/eslintrc/node_modules/ajv": {
+            "version": "6.15.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+            "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "balanced-match": "^1.0.0",
-                "concat-map": "0.0.1"
+                "fast-deep-equal": "^3.1.1",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.4.1",
+                "uri-js": "^4.2.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
             }
         },
-        "node_modules/@eslint/eslintrc/node_modules/minimatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+        "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
             "dev": true,
-            "dependencies": {
-                "brace-expansion": "^1.1.7"
-            },
-            "engines": {
-                "node": "*"
-            }
+            "license": "MIT"
         },
         "node_modules/@eslint/js": {
             "version": "9.39.1",
@@ -1094,9 +1072,9 @@
             }
         },
         "node_modules/@rollup/rollup-android-arm-eabi": {
-            "version": "4.50.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.50.0.tgz",
-            "integrity": "sha512-lVgpeQyy4fWN5QYebtW4buT/4kn4p4IJ+kDNB4uYNT5b8c8DLJDg6titg20NIg7E8RWwdWZORW6vUFfrLyG3KQ==",
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.3.tgz",
+            "integrity": "sha512-x35CNW/ANXG3hE/EZpRU8MXX1JDN86hBb2wMGAtltkz7pc6cxgjpy1OMMfDosOQ+2hWqIkag/fGok1Yady9nGw==",
             "cpu": [
                 "arm"
             ],
@@ -1108,9 +1086,9 @@
             ]
         },
         "node_modules/@rollup/rollup-android-arm64": {
-            "version": "4.50.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.50.0.tgz",
-            "integrity": "sha512-2O73dR4Dc9bp+wSYhviP6sDziurB5/HCym7xILKifWdE9UsOe2FtNcM+I4xZjKrfLJnq5UR8k9riB87gauiQtw==",
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.3.tgz",
+            "integrity": "sha512-xw3xtkDApIOGayehp2+Rz4zimfkaX65r4t47iy+ymQB2G4iJCBBfj0ogVg5jpvjpn8UWn/+q9tprxleYeNp3Hw==",
             "cpu": [
                 "arm64"
             ],
@@ -1122,9 +1100,9 @@
             ]
         },
         "node_modules/@rollup/rollup-darwin-arm64": {
-            "version": "4.50.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.50.0.tgz",
-            "integrity": "sha512-vwSXQN8T4sKf1RHr1F0s98Pf8UPz7pS6P3LG9NSmuw0TVh7EmaE+5Ny7hJOZ0M2yuTctEsHHRTMi2wuHkdS6Hg==",
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.3.tgz",
+            "integrity": "sha512-vo6Y5Qfpx7/5EaamIwi0WqW2+zfiusVihKatLvtN1VFVy3D13uERk/6gZLU1UiHRL6fDXqj/ELIeVRGnvcTE1g==",
             "cpu": [
                 "arm64"
             ],
@@ -1136,9 +1114,9 @@
             ]
         },
         "node_modules/@rollup/rollup-darwin-x64": {
-            "version": "4.50.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.50.0.tgz",
-            "integrity": "sha512-cQp/WG8HE7BCGyFVuzUg0FNmupxC+EPZEwWu2FCGGw5WDT1o2/YlENbm5e9SMvfDFR6FRhVCBePLqj0o8MN7Vw==",
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.3.tgz",
+            "integrity": "sha512-D+0QGcZhBzTN82weOnsSlY7V7+RMmPuF1CkbxyMAGE8+ZHeUjyb76ZiWmBlCu//AQQONvxcqRbwZTajZKqjuOw==",
             "cpu": [
                 "x64"
             ],
@@ -1150,9 +1128,9 @@
             ]
         },
         "node_modules/@rollup/rollup-freebsd-arm64": {
-            "version": "4.50.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.50.0.tgz",
-            "integrity": "sha512-UR1uTJFU/p801DvvBbtDD7z9mQL8J80xB0bR7DqW7UGQHRm/OaKzp4is7sQSdbt2pjjSS72eAtRh43hNduTnnQ==",
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.3.tgz",
+            "integrity": "sha512-6HnvHCT7fDyj6R0Ph7A6x8dQS/S38MClRWeDLqc0MdfWkxjiu1HSDYrdPhqSILzjTIC/pnXbbJbo+ft+gy/9hQ==",
             "cpu": [
                 "arm64"
             ],
@@ -1164,9 +1142,9 @@
             ]
         },
         "node_modules/@rollup/rollup-freebsd-x64": {
-            "version": "4.50.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.50.0.tgz",
-            "integrity": "sha512-G/DKyS6PK0dD0+VEzH/6n/hWDNPDZSMBmqsElWnCRGrYOb2jC0VSupp7UAHHQ4+QILwkxSMaYIbQ72dktp8pKA==",
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.3.tgz",
+            "integrity": "sha512-KHLgC3WKlUYW3ShFKnnosZDOJ0xjg9zp7au3sIm2bs/tGBeC2ipmvRh/N7JKi0t9Ue20C0dpEshi8WUubg+cnA==",
             "cpu": [
                 "x64"
             ],
@@ -1178,9 +1156,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-            "version": "4.50.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.50.0.tgz",
-            "integrity": "sha512-u72Mzc6jyJwKjJbZZcIYmd9bumJu7KNmHYdue43vT1rXPm2rITwmPWF0mmPzLm9/vJWxIRbao/jrQmxTO0Sm9w==",
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.3.tgz",
+            "integrity": "sha512-DV6fJoxEYWJOvaZIsok7KrYl0tPvga5OZ2yvKHNNYyk/2roMLqQAbGhr78EQ5YhHpnhLKJD3S1WFusAkmUuV5g==",
             "cpu": [
                 "arm"
             ],
@@ -1192,9 +1170,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-            "version": "4.50.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.50.0.tgz",
-            "integrity": "sha512-S4UefYdV0tnynDJV1mdkNawp0E5Qm2MtSs330IyHgaccOFrwqsvgigUD29uT+B/70PDY1eQ3t40+xf6wIvXJyg==",
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.3.tgz",
+            "integrity": "sha512-mQKoJAzvuOs6F+TZybQO4GOTSMUu7v0WdxEk24krQ/uUxXoPTtHjuaUuPmFhtBcM4K0ons8nrE3JyhTuCFtT/w==",
             "cpu": [
                 "arm"
             ],
@@ -1206,9 +1184,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm64-gnu": {
-            "version": "4.50.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.50.0.tgz",
-            "integrity": "sha512-1EhkSvUQXJsIhk4msxP5nNAUWoB4MFDHhtc4gAYvnqoHlaL9V3F37pNHabndawsfy/Tp7BPiy/aSa6XBYbaD1g==",
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.3.tgz",
+            "integrity": "sha512-Whjj2qoiJ6+OOJMGptTYazaJvjOJm+iKHpXQM1P3LzGjt7Ff++Tp7nH4N8J/BUA7R9IHfDyx4DJIflifwnbmIA==",
             "cpu": [
                 "arm64"
             ],
@@ -1220,9 +1198,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm64-musl": {
-            "version": "4.50.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.50.0.tgz",
-            "integrity": "sha512-EtBDIZuDtVg75xIPIK1l5vCXNNCIRM0OBPUG+tbApDuJAy9mKago6QxX+tfMzbCI6tXEhMuZuN1+CU8iDW+0UQ==",
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.3.tgz",
+            "integrity": "sha512-4YTNHKqGng5+yiZt3mg77nmyuCfmNfX4fPmyUapBcIk+BdwSwmCWGXOUxhXbBEkFHtoN5boLj/5NON+u5QC9tg==",
             "cpu": [
                 "arm64"
             ],
@@ -1233,10 +1211,24 @@
                 "linux"
             ]
         },
-        "node_modules/@rollup/rollup-linux-loongarch64-gnu": {
-            "version": "4.50.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.50.0.tgz",
-            "integrity": "sha512-BGYSwJdMP0hT5CCmljuSNx7+k+0upweM2M4YGfFBjnFSZMHOLYR0gEEj/dxyYJ6Zc6AiSeaBY8dWOa11GF/ppQ==",
+        "node_modules/@rollup/rollup-linux-loong64-gnu": {
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.3.tgz",
+            "integrity": "sha512-SU3kNlhkpI4UqlUc2VXPGK9o886ZsSeGfMAX2ba2b8DKmMXq4AL7KUrkSWVbb7koVqx41Yczx6dx5PNargIrEA==",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-loong64-musl": {
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.3.tgz",
+            "integrity": "sha512-6lDLl5h4TXpB1mTf2rQWnAk/LcXrx9vBfu/DT5TIPhvMhRWaZ5MxkIc8u4lJAmBo6klTe1ywXIUHFjylW505sg==",
             "cpu": [
                 "loong64"
             ],
@@ -1248,9 +1240,23 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-            "version": "4.50.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.50.0.tgz",
-            "integrity": "sha512-I1gSMzkVe1KzAxKAroCJL30hA4DqSi+wGc5gviD0y3IL/VkvcnAqwBf4RHXHyvH66YVHxpKO8ojrgc4SrWAnLg==",
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.3.tgz",
+            "integrity": "sha512-BMo8bOw8evlup/8G+cj5xWtPyp93xPdyoSN16Zy90Q2QZ0ZYRhCt6ZJSwbrRzG9HApFabjwj2p25TUPDWrhzqQ==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-ppc64-musl": {
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.3.tgz",
+            "integrity": "sha512-E0L8X1dZN1/Rph+5VPF6Xj2G7JJvMACVXtamTJIDrVI44Y3K+G8gQaMEAavbqCGTa16InptiVrX6eM6pmJ+7qA==",
             "cpu": [
                 "ppc64"
             ],
@@ -1262,9 +1268,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-            "version": "4.50.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.50.0.tgz",
-            "integrity": "sha512-bSbWlY3jZo7molh4tc5dKfeSxkqnf48UsLqYbUhnkdnfgZjgufLS/NTA8PcP/dnvct5CCdNkABJ56CbclMRYCA==",
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.3.tgz",
+            "integrity": "sha512-oZJ/WHaVfHUiRAtmTAeo3DcevNsVvH8mbvodjZy7D5QKvCefO371SiKRpxoDcCxB3PTRTLayWBkvmDQKTcX/sw==",
             "cpu": [
                 "riscv64"
             ],
@@ -1276,9 +1282,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-riscv64-musl": {
-            "version": "4.50.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.50.0.tgz",
-            "integrity": "sha512-LSXSGumSURzEQLT2e4sFqFOv3LWZsEF8FK7AAv9zHZNDdMnUPYH3t8ZlaeYYZyTXnsob3htwTKeWtBIkPV27iQ==",
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.3.tgz",
+            "integrity": "sha512-Dhbyh7j9FybM3YaTgaHmVALwA8AkUwTPccyCQ79TG9AJUsMQqgN1DDEZNr4+QUfwiWvLDumW5vdwzoeUF+TNxQ==",
             "cpu": [
                 "riscv64"
             ],
@@ -1290,9 +1296,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-s390x-gnu": {
-            "version": "4.50.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.50.0.tgz",
-            "integrity": "sha512-CxRKyakfDrsLXiCyucVfVWVoaPA4oFSpPpDwlMcDFQvrv3XY6KEzMtMZrA+e/goC8xxp2WSOxHQubP8fPmmjOQ==",
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.3.tgz",
+            "integrity": "sha512-cJd1X5XhHHlltkaypz1UcWLA8AcoIi1aWhsvaWDskD1oz2eKCypnqvTQ8ykMNI0RSmm7NkTdSqSSD7zM0xa6Ig==",
             "cpu": [
                 "s390x"
             ],
@@ -1304,9 +1310,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-x64-gnu": {
-            "version": "4.50.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.50.0.tgz",
-            "integrity": "sha512-8PrJJA7/VU8ToHVEPu14FzuSAqVKyo5gg/J8xUerMbyNkWkO9j2ExBho/68RnJsMGNJq4zH114iAttgm7BZVkA==",
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.3.tgz",
+            "integrity": "sha512-DAZDBHQfG2oQuhY7mc6I3/qB4LU2fQCjRvxbDwd/Jdvb9fypP4IJ4qmtu6lNjes6B531AI8cg1aKC2di97bUxA==",
             "cpu": [
                 "x64"
             ],
@@ -1318,9 +1324,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-x64-musl": {
-            "version": "4.50.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.50.0.tgz",
-            "integrity": "sha512-SkE6YQp+CzpyOrbw7Oc4MgXFvTw2UIBElvAvLCo230pyxOLmYwRPwZ/L5lBe/VW/qT1ZgND9wJfOsdy0XptRvw==",
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.3.tgz",
+            "integrity": "sha512-cRxsE8c13mZOh3vP+wLDxpQBRrOHDIGOWyDL93Sy0Ga8y515fBcC2pjUfFwUe5T7tqvTvWbCpg1URM/AXdWIXA==",
             "cpu": [
                 "x64"
             ],
@@ -1331,10 +1337,24 @@
                 "linux"
             ]
         },
+        "node_modules/@rollup/rollup-openbsd-x64": {
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.3.tgz",
+            "integrity": "sha512-QaWcIgRxqEdQdhJqW4DJctsH6HCmo5vHxY0krHSX4jMtOqfzC+dqDGuHM87bu4H8JBeibWx7jFz+h6/4C8wA5Q==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ]
+        },
         "node_modules/@rollup/rollup-openharmony-arm64": {
-            "version": "4.50.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.50.0.tgz",
-            "integrity": "sha512-PZkNLPfvXeIOgJWA804zjSFH7fARBBCpCXxgkGDRjjAhRLOR8o0IGS01ykh5GYfod4c2yiiREuDM8iZ+pVsT+Q==",
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.3.tgz",
+            "integrity": "sha512-AaXwSvUi3QIPtroAUw1t5yHGIyqKEXwH54WUocFolZhpGDruJcs8c+xPNDRn4XiQsS7MEwnYsHW2l0MBLDMkWg==",
             "cpu": [
                 "arm64"
             ],
@@ -1346,9 +1366,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-arm64-msvc": {
-            "version": "4.50.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.50.0.tgz",
-            "integrity": "sha512-q7cIIdFvWQoaCbLDUyUc8YfR3Jh2xx3unO8Dn6/TTogKjfwrax9SyfmGGK6cQhKtjePI7jRfd7iRYcxYs93esg==",
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.3.tgz",
+            "integrity": "sha512-65LAKM/bAWDqKNEelHlcHvm2V+Vfb8C6INFxQXRHCvaVN1rJfwr4NvdP4FyzUaLqWfaCGaadf6UbTm8xJeYfEg==",
             "cpu": [
                 "arm64"
             ],
@@ -1360,9 +1380,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-ia32-msvc": {
-            "version": "4.50.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.50.0.tgz",
-            "integrity": "sha512-XzNOVg/YnDOmFdDKcxxK410PrcbcqZkBmz+0FicpW5jtjKQxcW1BZJEQOF0NJa6JO7CZhett8GEtRN/wYLYJuw==",
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.3.tgz",
+            "integrity": "sha512-EEM2gyhBF5MFnI6vMKdX1LAosE627RGBzIoGMdLloPZkXrUN0Ckqgr2Qi8+J3zip/8NVVro3/FjB+tjhZUgUHA==",
             "cpu": [
                 "ia32"
             ],
@@ -1373,10 +1393,24 @@
                 "win32"
             ]
         },
+        "node_modules/@rollup/rollup-win32-x64-gnu": {
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.3.tgz",
+            "integrity": "sha512-E5Eb5H/DpxaoXH++Qkv28RcUJboMopmdDUALBczvHMf7hNIxaDZqwY5lK12UK1BHacSmvupoEWGu+n993Z0y1A==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
         "node_modules/@rollup/rollup-win32-x64-msvc": {
-            "version": "4.50.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.50.0.tgz",
-            "integrity": "sha512-xMmiWRR8sp72Zqwjgtf3QbZfF1wdh8X2ABu3EaozvZcyHJeU0r+XAnXdKgs4cCAp6ORoYoCygipYP1mjmbjrsg==",
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.3.tgz",
+            "integrity": "sha512-hPt/bgL5cE+Qp+/TPHBqptcAgPzgj46mPcg/16zNUmbQk0j+mOEQV/+Lqu8QRtDV3Ek95Q6FeFITpuhl6OTsAA==",
             "cpu": [
                 "x64"
             ],
@@ -1434,13 +1468,6 @@
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
             "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/@types/js-yaml": {
-            "version": "4.0.9",
-            "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
-            "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
             "dev": true,
             "license": "MIT"
         },
@@ -1878,15 +1905,16 @@
             }
         },
         "node_modules/ajv": {
-            "version": "6.12.6",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-            "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+            "version": "8.20.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+            "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "fast-deep-equal": "^3.1.1",
-                "fast-json-stable-stringify": "^2.0.0",
-                "json-schema-traverse": "^0.4.1",
-                "uri-js": "^4.2.2"
+                "fast-deep-equal": "^3.1.3",
+                "fast-uri": "^3.0.1",
+                "json-schema-traverse": "^1.0.0",
+                "require-from-string": "^2.0.2"
             },
             "funding": {
                 "type": "github",
@@ -1923,6 +1951,7 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
             "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+            "dev": true,
             "license": "Python-2.0"
         },
         "node_modules/array-buffer-byte-length": {
@@ -2131,9 +2160,9 @@
             "license": "MIT"
         },
         "node_modules/brace-expansion": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-            "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+            "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2295,12 +2324,6 @@
             "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/concat-map": {
-            "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-            "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-            "dev": true
         },
         "node_modules/crelt": {
             "version": "1.0.6",
@@ -2722,9 +2745,9 @@
             }
         },
         "node_modules/esbuild": {
-            "version": "0.23.1",
-            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.23.1.tgz",
-            "integrity": "sha512-VVNz/9Sa0bs5SELtn3f7qhJCDPCF5oMEl5cO9/SSinpE9hbPVvxbd572HH5AKiP7WD8INO53GgfDDhRjkylHEg==",
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
+            "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
             "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
@@ -2735,30 +2758,66 @@
                 "node": ">=18"
             },
             "optionalDependencies": {
-                "@esbuild/aix-ppc64": "0.23.1",
-                "@esbuild/android-arm": "0.23.1",
-                "@esbuild/android-arm64": "0.23.1",
-                "@esbuild/android-x64": "0.23.1",
-                "@esbuild/darwin-arm64": "0.23.1",
-                "@esbuild/darwin-x64": "0.23.1",
-                "@esbuild/freebsd-arm64": "0.23.1",
-                "@esbuild/freebsd-x64": "0.23.1",
-                "@esbuild/linux-arm": "0.23.1",
-                "@esbuild/linux-arm64": "0.23.1",
-                "@esbuild/linux-ia32": "0.23.1",
-                "@esbuild/linux-loong64": "0.23.1",
-                "@esbuild/linux-mips64el": "0.23.1",
-                "@esbuild/linux-ppc64": "0.23.1",
-                "@esbuild/linux-riscv64": "0.23.1",
-                "@esbuild/linux-s390x": "0.23.1",
-                "@esbuild/linux-x64": "0.23.1",
-                "@esbuild/netbsd-x64": "0.23.1",
-                "@esbuild/openbsd-arm64": "0.23.1",
-                "@esbuild/openbsd-x64": "0.23.1",
-                "@esbuild/sunos-x64": "0.23.1",
-                "@esbuild/win32-arm64": "0.23.1",
-                "@esbuild/win32-ia32": "0.23.1",
-                "@esbuild/win32-x64": "0.23.1"
+                "@esbuild/aix-ppc64": "0.28.0",
+                "@esbuild/android-arm": "0.28.0",
+                "@esbuild/android-arm64": "0.28.0",
+                "@esbuild/android-x64": "0.28.0",
+                "@esbuild/darwin-arm64": "0.28.0",
+                "@esbuild/darwin-x64": "0.28.0",
+                "@esbuild/freebsd-arm64": "0.28.0",
+                "@esbuild/freebsd-x64": "0.28.0",
+                "@esbuild/linux-arm": "0.28.0",
+                "@esbuild/linux-arm64": "0.28.0",
+                "@esbuild/linux-ia32": "0.28.0",
+                "@esbuild/linux-loong64": "0.28.0",
+                "@esbuild/linux-mips64el": "0.28.0",
+                "@esbuild/linux-ppc64": "0.28.0",
+                "@esbuild/linux-riscv64": "0.28.0",
+                "@esbuild/linux-s390x": "0.28.0",
+                "@esbuild/linux-x64": "0.28.0",
+                "@esbuild/netbsd-arm64": "0.28.0",
+                "@esbuild/netbsd-x64": "0.28.0",
+                "@esbuild/openbsd-arm64": "0.28.0",
+                "@esbuild/openbsd-x64": "0.28.0",
+                "@esbuild/openharmony-arm64": "0.28.0",
+                "@esbuild/sunos-x64": "0.28.0",
+                "@esbuild/win32-arm64": "0.28.0",
+                "@esbuild/win32-ia32": "0.28.0",
+                "@esbuild/win32-x64": "0.28.0"
+            }
+        },
+        "node_modules/esbuild/node_modules/@esbuild/netbsd-arm64": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+            "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/esbuild/node_modules/@esbuild/openharmony-arm64": {
+            "version": "0.28.0",
+            "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
+            "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openharmony"
+            ],
+            "engines": {
+                "node": ">=18"
             }
         },
         "node_modules/escape-string-regexp": {
@@ -2947,16 +3006,6 @@
                 "eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9"
             }
         },
-        "node_modules/eslint-plugin-import/node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-            "dev": true,
-            "dependencies": {
-                "balanced-match": "^1.0.0",
-                "concat-map": "0.0.1"
-            }
-        },
         "node_modules/eslint-plugin-import/node_modules/debug": {
             "version": "3.2.7",
             "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
@@ -2964,18 +3013,6 @@
             "dev": true,
             "dependencies": {
                 "ms": "^2.1.1"
-            }
-        },
-        "node_modules/eslint-plugin-import/node_modules/minimatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-            "dev": true,
-            "dependencies": {
-                "brace-expansion": "^1.1.7"
-            },
-            "engines": {
-                "node": "*"
             }
         },
         "node_modules/eslint-plugin-import/node_modules/semver": {
@@ -3013,43 +3050,6 @@
             },
             "peerDependencies": {
                 "eslint": ">=6.0.0"
-            }
-        },
-        "node_modules/eslint-plugin-json-schema-validator/node_modules/ajv": {
-            "version": "8.17.1",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-            "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
-            "dev": true,
-            "dependencies": {
-                "fast-deep-equal": "^3.1.3",
-                "fast-uri": "^3.0.1",
-                "json-schema-traverse": "^1.0.0",
-                "require-from-string": "^2.0.2"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/epoberezkin"
-            }
-        },
-        "node_modules/eslint-plugin-json-schema-validator/node_modules/json-schema-traverse": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-            "dev": true
-        },
-        "node_modules/eslint-plugin-json-schema-validator/node_modules/minimatch": {
-            "version": "8.0.4",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-8.0.4.tgz",
-            "integrity": "sha512-W0Wvr9HyFXZRGIDgCicunpQ299OKXs9RgZfaukz4qAW/pJhcpUfupc9c+OObPOFueNy8VSrZgEmDtk6Kh4WzDA==",
-            "dev": true,
-            "dependencies": {
-                "brace-expansion": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=16 || 14 >=14.17"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/eslint-plugin-n": {
@@ -3177,28 +3177,6 @@
                 "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7"
             }
         },
-        "node_modules/eslint-plugin-react/node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-            "dev": true,
-            "dependencies": {
-                "balanced-match": "^1.0.0",
-                "concat-map": "0.0.1"
-            }
-        },
-        "node_modules/eslint-plugin-react/node_modules/minimatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-            "dev": true,
-            "dependencies": {
-                "brace-expansion": "^1.1.7"
-            },
-            "engines": {
-                "node": "*"
-            }
-        },
         "node_modules/eslint-plugin-react/node_modules/resolve": {
             "version": "2.0.0-next.5",
             "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.5.tgz",
@@ -3262,27 +3240,29 @@
                 "url": "https://opencollective.com/eslint"
             }
         },
-        "node_modules/eslint/node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+        "node_modules/eslint/node_modules/ajv": {
+            "version": "6.15.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+            "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "balanced-match": "^1.0.0",
-                "concat-map": "0.0.1"
+                "fast-deep-equal": "^3.1.1",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.4.1",
+                "uri-js": "^4.2.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
             }
         },
-        "node_modules/eslint/node_modules/minimatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+        "node_modules/eslint/node_modules/json-schema-traverse": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
             "dev": true,
-            "dependencies": {
-                "brace-expansion": "^1.1.7"
-            },
-            "engines": {
-                "node": "*"
-            }
+            "license": "MIT"
         },
         "node_modules/espree": {
             "version": "10.4.0",
@@ -3401,7 +3381,8 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
             "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/fast-levenshtein": {
             "version": "2.0.6",
@@ -3410,9 +3391,9 @@
             "dev": true
         },
         "node_modules/fast-uri": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-            "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+            "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
             "dev": true,
             "funding": [
                 {
@@ -3423,7 +3404,8 @@
                     "type": "opencollective",
                     "url": "https://opencollective.com/fastify"
                 }
-            ]
+            ],
+            "license": "BSD-3-Clause"
         },
         "node_modules/fastq": {
             "version": "1.19.1",
@@ -3506,10 +3488,11 @@
             }
         },
         "node_modules/flatted": {
-            "version": "3.3.3",
-            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-            "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
-            "dev": true
+            "version": "3.4.2",
+            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+            "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+            "dev": true,
+            "license": "ISC"
         },
         "node_modules/for-each": {
             "version": "0.3.5",
@@ -3673,9 +3656,10 @@
             }
         },
         "node_modules/glob": {
-            "version": "10.4.5",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-            "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+            "version": "10.5.0",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+            "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+            "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -4446,9 +4430,10 @@
             "license": "MIT"
         },
         "node_modules/js-yaml": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-            "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+            "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "argparse": "^2.0.1"
@@ -4512,33 +4497,12 @@
                 "ajv": "^8.0.0"
             }
         },
-        "node_modules/json-schema-migrate/node_modules/ajv": {
-            "version": "8.17.1",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-            "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
-            "dev": true,
-            "dependencies": {
-                "fast-deep-equal": "^3.1.3",
-                "fast-uri": "^3.0.1",
-                "json-schema-traverse": "^1.0.0",
-                "require-from-string": "^2.0.2"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/epoberezkin"
-            }
-        },
-        "node_modules/json-schema-migrate/node_modules/json-schema-traverse": {
+        "node_modules/json-schema-traverse": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
             "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-            "dev": true
-        },
-        "node_modules/json-schema-traverse": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/json-stable-stringify-without-jsonify": {
             "version": "1.0.1",
@@ -4764,26 +4728,14 @@
                 "node": ">=8.6"
             }
         },
-        "node_modules/micromatch/node_modules/picomatch": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-            "dev": true,
-            "engines": {
-                "node": ">=8.6"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/jonschlinkert"
-            }
-        },
         "node_modules/minimatch": {
-            "version": "9.0.5",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-            "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+            "version": "9.0.9",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+            "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
-                "brace-expansion": "^2.0.1"
+                "brace-expansion": "^2.0.2"
             },
             "engines": {
                 "node": ">=16 || 14 >=14.17"
@@ -5153,9 +5105,9 @@
             "license": "ISC"
         },
         "node_modules/picomatch": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-            "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -5175,9 +5127,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.5.6",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-            "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+            "version": "8.5.14",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+            "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
             "dev": true,
             "funding": [
                 {
@@ -5378,9 +5330,9 @@
             }
         },
         "node_modules/rollup": {
-            "version": "4.50.0",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.50.0.tgz",
-            "integrity": "sha512-/Zl4D8zPifNmyGzJS+3kVoyXeDeT/GrsJM94sACNg9RtUE0hrHa1bNPtRSrfHTMH5HjRzce6K7rlTh3Khiw+pw==",
+            "version": "4.60.3",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.3.tgz",
+            "integrity": "sha512-pAQK9HalE84QSm4Po3EmWIZPd3FnjkShVkiMlz1iligWYkWQ7wHYd1PF/T7QZ5TVSD6uSTon5gBVMSM4JfBV+A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -5394,27 +5346,31 @@
                 "npm": ">=8.0.0"
             },
             "optionalDependencies": {
-                "@rollup/rollup-android-arm-eabi": "4.50.0",
-                "@rollup/rollup-android-arm64": "4.50.0",
-                "@rollup/rollup-darwin-arm64": "4.50.0",
-                "@rollup/rollup-darwin-x64": "4.50.0",
-                "@rollup/rollup-freebsd-arm64": "4.50.0",
-                "@rollup/rollup-freebsd-x64": "4.50.0",
-                "@rollup/rollup-linux-arm-gnueabihf": "4.50.0",
-                "@rollup/rollup-linux-arm-musleabihf": "4.50.0",
-                "@rollup/rollup-linux-arm64-gnu": "4.50.0",
-                "@rollup/rollup-linux-arm64-musl": "4.50.0",
-                "@rollup/rollup-linux-loongarch64-gnu": "4.50.0",
-                "@rollup/rollup-linux-ppc64-gnu": "4.50.0",
-                "@rollup/rollup-linux-riscv64-gnu": "4.50.0",
-                "@rollup/rollup-linux-riscv64-musl": "4.50.0",
-                "@rollup/rollup-linux-s390x-gnu": "4.50.0",
-                "@rollup/rollup-linux-x64-gnu": "4.50.0",
-                "@rollup/rollup-linux-x64-musl": "4.50.0",
-                "@rollup/rollup-openharmony-arm64": "4.50.0",
-                "@rollup/rollup-win32-arm64-msvc": "4.50.0",
-                "@rollup/rollup-win32-ia32-msvc": "4.50.0",
-                "@rollup/rollup-win32-x64-msvc": "4.50.0",
+                "@rollup/rollup-android-arm-eabi": "4.60.3",
+                "@rollup/rollup-android-arm64": "4.60.3",
+                "@rollup/rollup-darwin-arm64": "4.60.3",
+                "@rollup/rollup-darwin-x64": "4.60.3",
+                "@rollup/rollup-freebsd-arm64": "4.60.3",
+                "@rollup/rollup-freebsd-x64": "4.60.3",
+                "@rollup/rollup-linux-arm-gnueabihf": "4.60.3",
+                "@rollup/rollup-linux-arm-musleabihf": "4.60.3",
+                "@rollup/rollup-linux-arm64-gnu": "4.60.3",
+                "@rollup/rollup-linux-arm64-musl": "4.60.3",
+                "@rollup/rollup-linux-loong64-gnu": "4.60.3",
+                "@rollup/rollup-linux-loong64-musl": "4.60.3",
+                "@rollup/rollup-linux-ppc64-gnu": "4.60.3",
+                "@rollup/rollup-linux-ppc64-musl": "4.60.3",
+                "@rollup/rollup-linux-riscv64-gnu": "4.60.3",
+                "@rollup/rollup-linux-riscv64-musl": "4.60.3",
+                "@rollup/rollup-linux-s390x-gnu": "4.60.3",
+                "@rollup/rollup-linux-x64-gnu": "4.60.3",
+                "@rollup/rollup-linux-x64-musl": "4.60.3",
+                "@rollup/rollup-openbsd-x64": "4.60.3",
+                "@rollup/rollup-openharmony-arm64": "4.60.3",
+                "@rollup/rollup-win32-arm64-msvc": "4.60.3",
+                "@rollup/rollup-win32-ia32-msvc": "4.60.3",
+                "@rollup/rollup-win32-x64-gnu": "4.60.3",
+                "@rollup/rollup-win32-x64-msvc": "4.60.3",
                 "fsevents": "~2.3.2"
             }
         },
@@ -6090,14 +6046,14 @@
             "license": "MIT"
         },
         "node_modules/tinyglobby": {
-            "version": "0.2.14",
-            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
-            "integrity": "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==",
+            "version": "0.2.16",
+            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+            "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "fdir": "^6.4.4",
-                "picomatch": "^4.0.2"
+                "fdir": "^6.5.0",
+                "picomatch": "^4.0.4"
             },
             "engines": {
                 "node": ">=12.0.0"
@@ -6886,23 +6842,24 @@
             "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
             "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
             "dev": true,
+            "license": "BSD-2-Clause",
             "dependencies": {
                 "punycode": "^2.1.0"
             }
         },
         "node_modules/vite": {
-            "version": "7.1.4",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-7.1.4.tgz",
-            "integrity": "sha512-X5QFK4SGynAeeIt+A7ZWnApdUyHYm+pzv/8/A57LqSGcI88U6R6ipOs3uCesdc6yl7nl+zNO0t8LmqAdXcQihw==",
+            "version": "7.3.3",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.3.tgz",
+            "integrity": "sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "esbuild": "^0.25.0",
+                "esbuild": "^0.27.0",
                 "fdir": "^6.5.0",
                 "picomatch": "^4.0.3",
                 "postcss": "^8.5.6",
                 "rollup": "^4.43.0",
-                "tinyglobby": "^0.2.14"
+                "tinyglobby": "^0.2.15"
             },
             "bin": {
                 "vite": "bin/vite.js"
@@ -6989,9 +6946,9 @@
             }
         },
         "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
-            "version": "0.25.9",
-            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.9.tgz",
-            "integrity": "sha512-OaGtL73Jck6pBKjNIe24BnFE6agGl+6KxDtTfHhy1HmhthfKouEcOhqpSL64K4/0WCtbKFLOdzD/44cJ4k9opA==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+            "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
             "cpu": [
                 "ppc64"
             ],
@@ -7006,9 +6963,9 @@
             }
         },
         "node_modules/vite/node_modules/@esbuild/android-arm": {
-            "version": "0.25.9",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.9.tgz",
-            "integrity": "sha512-5WNI1DaMtxQ7t7B6xa572XMXpHAaI/9Hnhk8lcxF4zVN4xstUgTlvuGDorBguKEnZO70qwEcLpfifMLoxiPqHQ==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+            "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
             "cpu": [
                 "arm"
             ],
@@ -7023,9 +6980,9 @@
             }
         },
         "node_modules/vite/node_modules/@esbuild/android-arm64": {
-            "version": "0.25.9",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.9.tgz",
-            "integrity": "sha512-IDrddSmpSv51ftWslJMvl3Q2ZT98fUSL2/rlUXuVqRXHCs5EUF1/f+jbjF5+NG9UffUDMCiTyh8iec7u8RlTLg==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+            "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
             "cpu": [
                 "arm64"
             ],
@@ -7040,9 +6997,9 @@
             }
         },
         "node_modules/vite/node_modules/@esbuild/android-x64": {
-            "version": "0.25.9",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.9.tgz",
-            "integrity": "sha512-I853iMZ1hWZdNllhVZKm34f4wErd4lMyeV7BLzEExGEIZYsOzqDWDf+y082izYUE8gtJnYHdeDpN/6tUdwvfiw==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+            "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
             "cpu": [
                 "x64"
             ],
@@ -7057,9 +7014,9 @@
             }
         },
         "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
-            "version": "0.25.9",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.9.tgz",
-            "integrity": "sha512-XIpIDMAjOELi/9PB30vEbVMs3GV1v2zkkPnuyRRURbhqjyzIINwj+nbQATh4H9GxUgH1kFsEyQMxwiLFKUS6Rg==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+            "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
             "cpu": [
                 "arm64"
             ],
@@ -7074,9 +7031,9 @@
             }
         },
         "node_modules/vite/node_modules/@esbuild/darwin-x64": {
-            "version": "0.25.9",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.9.tgz",
-            "integrity": "sha512-jhHfBzjYTA1IQu8VyrjCX4ApJDnH+ez+IYVEoJHeqJm9VhG9Dh2BYaJritkYK3vMaXrf7Ogr/0MQ8/MeIefsPQ==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+            "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
             "cpu": [
                 "x64"
             ],
@@ -7091,9 +7048,9 @@
             }
         },
         "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
-            "version": "0.25.9",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.9.tgz",
-            "integrity": "sha512-z93DmbnY6fX9+KdD4Ue/H6sYs+bhFQJNCPZsi4XWJoYblUqT06MQUdBCpcSfuiN72AbqeBFu5LVQTjfXDE2A6Q==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+            "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
             "cpu": [
                 "arm64"
             ],
@@ -7108,9 +7065,9 @@
             }
         },
         "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
-            "version": "0.25.9",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.9.tgz",
-            "integrity": "sha512-mrKX6H/vOyo5v71YfXWJxLVxgy1kyt1MQaD8wZJgJfG4gq4DpQGpgTB74e5yBeQdyMTbgxp0YtNj7NuHN0PoZg==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+            "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
             "cpu": [
                 "x64"
             ],
@@ -7125,9 +7082,9 @@
             }
         },
         "node_modules/vite/node_modules/@esbuild/linux-arm": {
-            "version": "0.25.9",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.9.tgz",
-            "integrity": "sha512-HBU2Xv78SMgaydBmdor38lg8YDnFKSARg1Q6AT0/y2ezUAKiZvc211RDFHlEZRFNRVhcMamiToo7bDx3VEOYQw==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+            "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
             "cpu": [
                 "arm"
             ],
@@ -7142,9 +7099,9 @@
             }
         },
         "node_modules/vite/node_modules/@esbuild/linux-arm64": {
-            "version": "0.25.9",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.9.tgz",
-            "integrity": "sha512-BlB7bIcLT3G26urh5Dmse7fiLmLXnRlopw4s8DalgZ8ef79Jj4aUcYbk90g8iCa2467HX8SAIidbL7gsqXHdRw==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+            "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
             "cpu": [
                 "arm64"
             ],
@@ -7159,9 +7116,9 @@
             }
         },
         "node_modules/vite/node_modules/@esbuild/linux-ia32": {
-            "version": "0.25.9",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.9.tgz",
-            "integrity": "sha512-e7S3MOJPZGp2QW6AK6+Ly81rC7oOSerQ+P8L0ta4FhVi+/j/v2yZzx5CqqDaWjtPFfYz21Vi1S0auHrap3Ma3A==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+            "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
             "cpu": [
                 "ia32"
             ],
@@ -7176,9 +7133,9 @@
             }
         },
         "node_modules/vite/node_modules/@esbuild/linux-loong64": {
-            "version": "0.25.9",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.9.tgz",
-            "integrity": "sha512-Sbe10Bnn0oUAB2AalYztvGcK+o6YFFA/9829PhOCUS9vkJElXGdphz0A3DbMdP8gmKkqPmPcMJmJOrI3VYB1JQ==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+            "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
             "cpu": [
                 "loong64"
             ],
@@ -7193,9 +7150,9 @@
             }
         },
         "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
-            "version": "0.25.9",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.9.tgz",
-            "integrity": "sha512-YcM5br0mVyZw2jcQeLIkhWtKPeVfAerES5PvOzaDxVtIyZ2NUBZKNLjC5z3/fUlDgT6w89VsxP2qzNipOaaDyA==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+            "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
             "cpu": [
                 "mips64el"
             ],
@@ -7210,9 +7167,9 @@
             }
         },
         "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
-            "version": "0.25.9",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.9.tgz",
-            "integrity": "sha512-++0HQvasdo20JytyDpFvQtNrEsAgNG2CY1CLMwGXfFTKGBGQT3bOeLSYE2l1fYdvML5KUuwn9Z8L1EWe2tzs1w==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+            "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
             "cpu": [
                 "ppc64"
             ],
@@ -7227,9 +7184,9 @@
             }
         },
         "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
-            "version": "0.25.9",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.9.tgz",
-            "integrity": "sha512-uNIBa279Y3fkjV+2cUjx36xkx7eSjb8IvnL01eXUKXez/CBHNRw5ekCGMPM0BcmqBxBcdgUWuUXmVWwm4CH9kg==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+            "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
             "cpu": [
                 "riscv64"
             ],
@@ -7244,9 +7201,9 @@
             }
         },
         "node_modules/vite/node_modules/@esbuild/linux-s390x": {
-            "version": "0.25.9",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.9.tgz",
-            "integrity": "sha512-Mfiphvp3MjC/lctb+7D287Xw1DGzqJPb/J2aHHcHxflUo+8tmN/6d4k6I2yFR7BVo5/g7x2Monq4+Yew0EHRIA==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+            "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
             "cpu": [
                 "s390x"
             ],
@@ -7261,9 +7218,9 @@
             }
         },
         "node_modules/vite/node_modules/@esbuild/linux-x64": {
-            "version": "0.25.9",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.9.tgz",
-            "integrity": "sha512-iSwByxzRe48YVkmpbgoxVzn76BXjlYFXC7NvLYq+b+kDjyyk30J0JY47DIn8z1MO3K0oSl9fZoRmZPQI4Hklzg==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+            "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
             "cpu": [
                 "x64"
             ],
@@ -7277,10 +7234,27 @@
                 "node": ">=18"
             }
         },
+        "node_modules/vite/node_modules/@esbuild/netbsd-arm64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+            "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
-            "version": "0.25.9",
-            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.9.tgz",
-            "integrity": "sha512-RLLdkflmqRG8KanPGOU7Rpg829ZHu8nFy5Pqdi9U01VYtG9Y0zOG6Vr2z4/S+/3zIyOxiK6cCeYNWOFR9QP87g==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+            "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
             "cpu": [
                 "x64"
             ],
@@ -7295,9 +7269,9 @@
             }
         },
         "node_modules/vite/node_modules/@esbuild/openbsd-arm64": {
-            "version": "0.25.9",
-            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.9.tgz",
-            "integrity": "sha512-YaFBlPGeDasft5IIM+CQAhJAqS3St3nJzDEgsgFixcfZeyGPCd6eJBWzke5piZuZ7CtL656eOSYKk4Ls2C0FRQ==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+            "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
             "cpu": [
                 "arm64"
             ],
@@ -7312,9 +7286,9 @@
             }
         },
         "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
-            "version": "0.25.9",
-            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.9.tgz",
-            "integrity": "sha512-1MkgTCuvMGWuqVtAvkpkXFmtL8XhWy+j4jaSO2wxfJtilVCi0ZE37b8uOdMItIHz4I6z1bWWtEX4CJwcKYLcuA==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+            "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
             "cpu": [
                 "x64"
             ],
@@ -7328,10 +7302,27 @@
                 "node": ">=18"
             }
         },
+        "node_modules/vite/node_modules/@esbuild/openharmony-arm64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+            "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openharmony"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/vite/node_modules/@esbuild/sunos-x64": {
-            "version": "0.25.9",
-            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.9.tgz",
-            "integrity": "sha512-WjH4s6hzo00nNezhp3wFIAfmGZ8U7KtrJNlFMRKxiI9mxEK1scOMAaa9i4crUtu+tBr+0IN6JCuAcSBJZfnphw==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+            "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
             "cpu": [
                 "x64"
             ],
@@ -7346,9 +7337,9 @@
             }
         },
         "node_modules/vite/node_modules/@esbuild/win32-arm64": {
-            "version": "0.25.9",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.9.tgz",
-            "integrity": "sha512-mGFrVJHmZiRqmP8xFOc6b84/7xa5y5YvR1x8djzXpJBSv/UsNK6aqec+6JDjConTgvvQefdGhFDAs2DLAds6gQ==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+            "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
             "cpu": [
                 "arm64"
             ],
@@ -7363,9 +7354,9 @@
             }
         },
         "node_modules/vite/node_modules/@esbuild/win32-ia32": {
-            "version": "0.25.9",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.9.tgz",
-            "integrity": "sha512-b33gLVU2k11nVx1OhX3C8QQP6UHQK4ZtN56oFWvVXvz2VkDoe6fbG8TOgHFxEvqeqohmRnIHe5A1+HADk4OQww==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+            "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
             "cpu": [
                 "ia32"
             ],
@@ -7380,9 +7371,9 @@
             }
         },
         "node_modules/vite/node_modules/@esbuild/win32-x64": {
-            "version": "0.25.9",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.9.tgz",
-            "integrity": "sha512-PPOl1mi6lpLNQxnGoyAfschAodRFYXJ+9fs6WHXz7CSWKbOqiMZsubC+BQsVKuul+3vKLuwTHsS2c2y9EoKwxQ==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+            "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
             "cpu": [
                 "x64"
             ],
@@ -7397,9 +7388,9 @@
             }
         },
         "node_modules/vite/node_modules/esbuild": {
-            "version": "0.25.9",
-            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.9.tgz",
-            "integrity": "sha512-CRbODhYyQx3qp7ZEwzxOk4JBqmD/seJrzPa/cGjY1VtIn5E09Oi9/dB4JwctnfZ8Q8iT7rioVv5k/FNT/uf54g==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+            "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
             "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
@@ -7410,32 +7401,32 @@
                 "node": ">=18"
             },
             "optionalDependencies": {
-                "@esbuild/aix-ppc64": "0.25.9",
-                "@esbuild/android-arm": "0.25.9",
-                "@esbuild/android-arm64": "0.25.9",
-                "@esbuild/android-x64": "0.25.9",
-                "@esbuild/darwin-arm64": "0.25.9",
-                "@esbuild/darwin-x64": "0.25.9",
-                "@esbuild/freebsd-arm64": "0.25.9",
-                "@esbuild/freebsd-x64": "0.25.9",
-                "@esbuild/linux-arm": "0.25.9",
-                "@esbuild/linux-arm64": "0.25.9",
-                "@esbuild/linux-ia32": "0.25.9",
-                "@esbuild/linux-loong64": "0.25.9",
-                "@esbuild/linux-mips64el": "0.25.9",
-                "@esbuild/linux-ppc64": "0.25.9",
-                "@esbuild/linux-riscv64": "0.25.9",
-                "@esbuild/linux-s390x": "0.25.9",
-                "@esbuild/linux-x64": "0.25.9",
-                "@esbuild/netbsd-arm64": "0.25.9",
-                "@esbuild/netbsd-x64": "0.25.9",
-                "@esbuild/openbsd-arm64": "0.25.9",
-                "@esbuild/openbsd-x64": "0.25.9",
-                "@esbuild/openharmony-arm64": "0.25.9",
-                "@esbuild/sunos-x64": "0.25.9",
-                "@esbuild/win32-arm64": "0.25.9",
-                "@esbuild/win32-ia32": "0.25.9",
-                "@esbuild/win32-x64": "0.25.9"
+                "@esbuild/aix-ppc64": "0.27.7",
+                "@esbuild/android-arm": "0.27.7",
+                "@esbuild/android-arm64": "0.27.7",
+                "@esbuild/android-x64": "0.27.7",
+                "@esbuild/darwin-arm64": "0.27.7",
+                "@esbuild/darwin-x64": "0.27.7",
+                "@esbuild/freebsd-arm64": "0.27.7",
+                "@esbuild/freebsd-x64": "0.27.7",
+                "@esbuild/linux-arm": "0.27.7",
+                "@esbuild/linux-arm64": "0.27.7",
+                "@esbuild/linux-ia32": "0.27.7",
+                "@esbuild/linux-loong64": "0.27.7",
+                "@esbuild/linux-mips64el": "0.27.7",
+                "@esbuild/linux-ppc64": "0.27.7",
+                "@esbuild/linux-riscv64": "0.27.7",
+                "@esbuild/linux-s390x": "0.27.7",
+                "@esbuild/linux-x64": "0.27.7",
+                "@esbuild/netbsd-arm64": "0.27.7",
+                "@esbuild/netbsd-x64": "0.27.7",
+                "@esbuild/openbsd-arm64": "0.27.7",
+                "@esbuild/openbsd-x64": "0.27.7",
+                "@esbuild/openharmony-arm64": "0.27.7",
+                "@esbuild/sunos-x64": "0.27.7",
+                "@esbuild/win32-arm64": "0.27.7",
+                "@esbuild/win32-ia32": "0.27.7",
+                "@esbuild/win32-x64": "0.27.7"
             }
         },
         "node_modules/vitest": {
@@ -7844,15 +7835,18 @@
             "license": "MIT"
         },
         "node_modules/yaml": {
-            "version": "2.8.1",
-            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
-            "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
-            "dev": true,
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+            "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+            "license": "ISC",
             "bin": {
                 "yaml": "bin.mjs"
             },
             "engines": {
                 "node": ">= 14.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/eemeli"
             }
         },
         "node_modules/yaml-eslint-parser": {

--- a/package.json
+++ b/package.json
@@ -20,17 +20,15 @@
         "tree": "tree -L 3 -I 'node_modules|coverage'"
     },
     "dependencies": {
-        "js-yaml": "^4.1.0"
+        "yaml": "^2.9.0"
     },
     "devDependencies": {
         "@eslint/js": "^9.39.1",
         "@microsoft/eslint-plugin-sdl": "^1.1.0",
-        "@types/js-yaml": "^4.0.9",
         "@types/node": "^20.12.12",
         "@vitest/coverage-v8": "^3.2.4",
-        "esbuild": "^0.23.0",
+        "esbuild": "^0.28.0",
         "eslint": "^9.39.1",
-        "eslint-plugin-import": "^2.32.0",
         "eslint-plugin-obsidianmd": "^0.1.7",
         "jsdom": "^26.1.0",
         "obsidian": "^1.5.0",
@@ -38,5 +36,16 @@
         "typescript": "^5.5.0",
         "typescript-eslint": "^8.46.3",
         "vitest": "^3.2.4"
+    },
+    "overrides": {
+        "brace-expansion": "^2.0.1",
+        "fast-uri": "^3.0.3",
+        "flatted": "^3.3.3",
+        "glob": "^10.4.5",
+        "js-yaml": "^4.1.1",
+        "minimatch": "^9.0.9",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.4.49",
+        "rollup": "^4.18.0"
     }
 }

--- a/src/app/plugin.ts
+++ b/src/app/plugin.ts
@@ -33,9 +33,7 @@ export default class HotstringsPlugin extends Plugin {
             id: "open-settings",
             name: "Open settings",
             callback: () => {
-                // @ts-expect-error Obsidian internal API - setting.open() and openTabById() exist at runtime but are not in type definitions
                 this.app.setting.open();
-                // @ts-expect-error Obsidian internal API - setting.open() and openTabById() exist at runtime but are not in type definitions
                 this.app.setting.openTabById(this.manifest.id);
             }
         });
@@ -52,8 +50,8 @@ export default class HotstringsPlugin extends Plugin {
     }
 
     async loadSettings() {
-        const saved = await this.loadData();
-        const savedSnippets = (saved?.snippets ?? {}) as Record<string, string>;
+        const saved = (await this.loadData()) as { snippets?: Record<string, string> } | null;
+        const savedSnippets = saved?.snippets ?? {};
         this.settings = {
             snippets: {
                 ...DEFAULT_SNIPPETS,

--- a/src/engine/edit.ts
+++ b/src/engine/edit.ts
@@ -2,7 +2,7 @@ import type { AppliedReplacement, EditPlan, ExpandInput, TriggerMatch } from "./
 
 /** Build a plan for replacement and cursor positioning */
 export function buildEdit(
-    input: ExpandInput,
+    _input: ExpandInput,
     m: TriggerMatch,
     applied: AppliedReplacement
 ): EditPlan {

--- a/src/packages/espanso.ts
+++ b/src/packages/espanso.ts
@@ -1,5 +1,5 @@
 // Lightweight converter from Espanso YAML to { trigger: replacement }
-import yaml from "js-yaml";
+import * as YAML from "yaml";
 import type { EspansoDocument } from "../services/package-types";
 
 /**
@@ -11,7 +11,7 @@ import type { EspansoDocument } from "../services/package-types";
  * We ignore complex placeholders/conditions. Leading ":" in triggers is removed.
  */
 export function espansoYamlToSnippets(text: string): Record<string, string> {
-    const doc = yaml.load(text) as EspansoDocument;
+    const doc = YAML.parse(text) as EspansoDocument;
     const out: Record<string, string> = {};
     if (!doc || typeof doc !== "object") return out;
 

--- a/src/services/community-packages.ts
+++ b/src/services/community-packages.ts
@@ -1,9 +1,19 @@
-import * as yaml from "js-yaml";
+import * as YAML from "yaml";
 import { App, TFolder, TFile, requestUrl } from "obsidian";
 import { validatePackage, validatePackageFile } from "./package-validator";
 import type { PackageData } from "./package-types";
 
 // No built-in packages - all packages come from GitHub API
+
+interface GitHubIssueResponse {
+  html_url: string;
+}
+
+interface GitHubContentEntry {
+  name: string;
+  download_url: string;
+  type?: string;
+}
 
 export interface PackageItem {
     id?: string;
@@ -73,7 +83,7 @@ export async function loadDynamicCommunityPackages(app: App): Promise<PackageIte
       if (file instanceof TFile && (file.path.endsWith('.yml') || file.path.endsWith('.yaml'))) {
         try {
           const content = await app.vault.read(file);
-          const packageData = yaml.load(content) as PackageData;
+          const packageData = YAML.parse(content) as PackageData;
           
           if (packageData && typeof packageData === 'object' && 'name' in packageData && typeof packageData.name === 'string') {
             const tags = Array.isArray(packageData.tags) ? packageData.tags.filter((t): t is string => typeof t === 'string') : [];
@@ -114,11 +124,11 @@ interface UserInfo {
 /**
  * Creates a GitHub Issue for package submission
  */
-export async function createPackageIssue(app: App, packageData: PackageData, userInfo: UserInfo): Promise<{ success: boolean; issueUrl?: string; error?: string }> {
+export async function createPackageIssue(_app: App, packageData: PackageData, userInfo: UserInfo): Promise<{ success: boolean; issueUrl?: string; error?: string }> {
   try {
     const issue = {
       title: `[Package Submission] ${packageData.name}`,
-      body: `## Package Information\n\n**Author:** ${userInfo.author || 'Anonymous'}\n**Category:** ${packageData.category || 'other'}\n**Description:** ${packageData.description || 'No description'}\n\n## Package YAML\n\n\`\`\`yaml\n${yaml.dump(packageData)}\n\`\`\`\n\n## Review Checklist\n\n- [ ] Package follows naming conventions\n- [ ] All snippets work correctly\n- [ ] YAML is valid and well-formatted\n- [ ] Content is appropriate and useful\n- [ ] Package fits the chosen category\n- [ ] No duplicate triggers with existing packages`,
+      body: `## Package Information\n\n**Author:** ${userInfo.author || 'Anonymous'}\n**Category:** ${packageData.category || 'other'}\n**Description:** ${packageData.description || 'No description'}\n\n## Package YAML\n\n\`\`\`yaml\n${YAML.stringify(packageData)}\n\`\`\`\n\n## Review Checklist\n\n- [ ] Package follows naming conventions\n- [ ] All snippets work correctly\n- [ ] YAML is valid and well-formatted\n- [ ] Content is appropriate and useful\n- [ ] Package fits the chosen category\n- [ ] No duplicate triggers with existing packages`,
       labels: ['package-submission', 'pending-review']
     };
 
@@ -142,7 +152,7 @@ export async function createPackageIssue(app: App, packageData: PackageData, use
       throw new Error(`GitHub API error: ${response.status}`);
     }
 
-    const result = JSON.parse(response.text);
+    const result = JSON.parse(response.text) as GitHubIssueResponse;
     return { success: true, issueUrl: result.html_url };
   } catch (error) {
     return { success: false, error: (error as Error).message };
@@ -165,8 +175,8 @@ export async function loadCommunityPackagesFromGitHub(): Promise<PackageItem[]> 
       throw new Error(`GitHub API error: ${response.status}`);
     }
 
-    const files = JSON.parse(response.text);
-    
+    const files = JSON.parse(response.text) as GitHubContentEntry[];
+
     // Handle case where directory exists but is empty
     if (!Array.isArray(files) || files.length === 0) {
       return [];
@@ -181,7 +191,7 @@ export async function loadCommunityPackagesFromGitHub(): Promise<PackageItem[]> 
             url: file.download_url
           });
           const content = contentResponse.text;
-          const packageData = yaml.load(content) as PackageData;
+          const packageData = YAML.parse(content) as PackageData;
 
           if (packageData && packageData.name && packageData.snippets) {
             const snippets = convertSnippetsToObject(packageData.snippets);
@@ -400,10 +410,10 @@ export async function processPackageSubmission(
         }
         
         // Convert package data to YAML
-        const yamlContent = yaml.dump(packageData, { 
+        const yamlContent = YAML.stringify(packageData, {
           indent: 2,
-          lineWidth: -1,
-          noRefs: true
+          lineWidth: 0,
+          aliasDuplicateObjects: false
         });
         
         // Extract filename from filePath

--- a/src/services/feedback-form.test.ts
+++ b/src/services/feedback-form.test.ts
@@ -37,7 +37,7 @@ describe("feedback-form", () => {
     });
     
     // Mock document object
-    Object.defineProperty(global, 'document', {
+    Object.defineProperty(global, 'activeDocument', {
       value: {
         body: {
           classList: {
@@ -175,7 +175,7 @@ describe("feedback-form", () => {
     });
 
     it("should detect light theme", () => {
-      Object.defineProperty(global, 'document', {
+      Object.defineProperty(global, 'activeDocument', {
         value: {
           body: {
             classList: {

--- a/src/services/feedback-form.ts
+++ b/src/services/feedback-form.ts
@@ -147,7 +147,6 @@ export function buildPackageFormUrl(
  * @returns Collected metadata object
  */
 export function collectSystemMeta(app: App, pluginVersion: string): FeedbackMeta {
-  // @ts-expect-error Obsidian internal API - app.version exists at runtime but is not in type definitions
   const obsidianVersion = app.version || "Unknown";
   
   // Detect platform using Obsidian Platform API
@@ -169,7 +168,7 @@ export function collectSystemMeta(app: App, pluginVersion: string): FeedbackMeta
   const locale = navigator.language || 'en-US';
   
   // Try to get theme (this might not be available in all contexts)
-  const theme = document.body.classList.contains('theme-dark') ? 'dark' : 'light';
+  const theme = activeDocument.body.classList.contains('theme-dark') ? 'dark' : 'light';
   
   return {
     plugin: pluginVersion,

--- a/src/services/package-submission-form.test.ts
+++ b/src/services/package-submission-form.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import * as yaml from 'js-yaml';
+import * as YAML from 'yaml';
 import {
   getPackageSubmissionFormUrl,
   validatePackageForSubmission,
@@ -9,9 +9,9 @@ import {
 } from './package-submission-form';
 
 // Mock dependencies
-vi.mock('js-yaml', () => ({
-  load: vi.fn(),
-  dump: vi.fn()
+vi.mock('yaml', () => ({
+  parse: vi.fn(),
+  stringify: vi.fn()
 }));
 
 vi.mock('./feedback-form', () => ({
@@ -38,7 +38,7 @@ describe('package-submission-form', () => {
   describe('validateAndPreparePackageData', () => {
     it('should handle YAML parsing errors', () => {
       const invalidYaml = 'invalid: yaml: content: [';
-      vi.mocked(yaml.load).mockImplementation(() => {
+      vi.mocked(YAML.parse).mockImplementation(() => {
         throw new Error('YAML parsing error');
       });
 
@@ -60,7 +60,7 @@ describe('package-submission-form', () => {
 
     it('should handle non-object parsed data', () => {
       const stringData = 'just a string';
-      vi.mocked(yaml.load).mockReturnValue(stringData);
+      vi.mocked(YAML.parse).mockReturnValue(stringData);
 
       const result = validateAndPreparePackageData('yaml string');
 
@@ -84,7 +84,7 @@ describe('package-submission-form', () => {
         warnings: []
       });
 
-      vi.mocked(yaml.dump).mockReturnValue('test yaml');
+      vi.mocked(YAML.stringify).mockReturnValue('test yaml');
 
       const result = validateAndPreparePackageData(packageData, 'test@example.com', 'Test User');
 

--- a/src/services/package-submission-form.ts
+++ b/src/services/package-submission-form.ts
@@ -3,7 +3,7 @@
  * Handles package submission through Google Forms as an alternative to GitHub Issues
  */
 
-import * as yaml from "js-yaml";
+import * as YAML from "yaml";
 import { App } from "obsidian";
 import { 
   buildPackageFormUrl, 
@@ -46,7 +46,7 @@ export function validateAndPreparePackageData(
     // Parse YAML if it's a string
     let parsedData: PackageData;
     if (typeof packageData === 'string') {
-      parsedData = yaml.load(packageData) as PackageData;
+      parsedData = YAML.parse(packageData) as PackageData;
     } else {
       parsedData = packageData;
     }
@@ -87,10 +87,10 @@ export function validateAndPreparePackageData(
       license: parsedData.license || '',
       homepage: parsedData.homepage || '',
       readme: parsedData.readme || '',
-      yamlContent: typeof packageData === 'string' ? packageData : yaml.dump(parsedData, { 
+      yamlContent: typeof packageData === 'string' ? packageData : YAML.stringify(parsedData, {
         indent: 2,
-        lineWidth: -1,
-        noRefs: true
+        lineWidth: 0,
+        aliasDuplicateObjects: false
       }),
       submitterEmail: submitterEmail || '',
       submitterName: submitterName || ''

--- a/src/services/package-validator.ts
+++ b/src/services/package-validator.ts
@@ -177,7 +177,7 @@ function validateNamingConventions(packageData: PackageData, errors: string[]) {
   }
 }
 
-function validateContentQuality(packageData: PackageData, errors: string[], warnings: string[]) {
+function validateContentQuality(packageData: PackageData, _errors: string[], warnings: string[]) {
   // Check for inappropriate content
   const inappropriateWords = ["spam", "test", "dummy", "placeholder"];
   

--- a/src/store/snippets.ts
+++ b/src/store/snippets.ts
@@ -51,7 +51,7 @@ export function mergeDefaults(
 }
 
 export function replaceAllSnippets(
-    settings: SnipSidianSettings,
+    _settings: SnipSidianSettings,
     incoming: unknown
 ): SnipSidianSettings | null {
     if (!isRecordOfString(incoming)) return null;

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -6,8 +6,11 @@
   box-sizing: border-box;
 }
 
-/* Text overflow and horizontal scroll fixes */
+/* Text overflow and horizontal scroll fixes + heading rhythm vars */
 .mod-settings .snipsidian-settings {
+  --snip-h2-mb: 6px;
+  --snip-h3-mt: 18px;
+  --snip-h3-mb: 6px;
   overflow-x: hidden;
   word-wrap: break-word;
   word-break: break-word;
@@ -15,6 +18,8 @@
 
 .mod-settings .snipsidian-settings .setting-item {
   overflow-x: hidden;
+  padding-top: 8px;
+  padding-bottom: 8px;
 }
 
 .mod-settings .snipsidian-settings .setting-item-name {
@@ -86,19 +91,19 @@
   gap: 8px; 
 }
 
-.snipsidian-group-checkbox { 
-  margin-left: 4px; 
-}
-
-.snipsidian-row-checkbox { 
-  margin-right: 8px; 
-}
-
-.snipsidian-row-checkbox,
 .snipsidian-group-checkbox {
-  appearance: checkbox; 
+  margin-left: 4px;
+  appearance: checkbox;
   -webkit-appearance: checkbox;
-  width: 14px; 
+  width: 14px;
+  height: 14px;
+}
+
+.snipsidian-row-checkbox {
+  margin-right: 8px;
+  appearance: checkbox;
+  -webkit-appearance: checkbox;
+  width: 14px;
   height: 14px;
 }
 

--- a/src/styles/components/forms.css
+++ b/src/styles/components/forms.css
@@ -168,7 +168,7 @@
 }
 
 .contact-section h3 {
-  margin: 0 0 var(--spacing-md) 0;
+  margin: 0 0 var(--spacing-md);
   color: var(--text-normal);
   font-size: 16px;
   font-weight: 600;

--- a/src/styles/components/modals.css
+++ b/src/styles/components/modals.css
@@ -1,10 +1,10 @@
 /* ============ Modal Components ============ */
 
 /* Modal base styles */
-.modal .snipsidian-modal {
+.modal .snipsidian-modal.snipsidian-modal {
   width: min(500px, 90vw);
   max-width: 90vw;
-  overflow-x: hidden !important;
+  overflow-x: hidden;
 }
 
 .modal .snipsidian-modal * {
@@ -12,8 +12,8 @@
 }
 
 /* Kill horizontal scroll on Obsidian modal wrapper - only for our modals */
-.modal .snipsidian-modal .modal-content { 
-  overflow-x: hidden !important; 
+.modal .snipsidian-modal.snipsidian-modal .modal-content {
+  overflow-x: hidden;
 }
 
 /* Modal title */

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -21,13 +21,7 @@
 /* ============ Legacy Styles (временно) ============ */
 /* Эти стили будут постепенно перенесены в модули */
 
-/* Settings panel (legacy bits) */
-.mod-settings .snipsidian-settings {
-  --snip-h2-mb: 6px;
-  --snip-h3-mt: 18px;
-  --snip-h3-mb: 6px;
-}
-
+/* Settings panel heading rhythm (vars + .setting-item padding live in base.css) */
 .mod-settings .snipsidian-settings h2 {
   margin-top: 0;
   margin-bottom: var(--snip-h2-mb);
@@ -43,11 +37,6 @@
 .mod-settings .snipsidian-settings h3 {
   margin-top: var(--snip-h3-mt);
   margin-bottom: var(--snip-h3-mb);
-}
-
-.mod-settings .snipsidian-settings .setting-item {
-  padding-top: 8px;
-  padding-bottom: 8px;
 }
 
 .mod-settings .snipsidian-settings h3 + .setting-item {
@@ -75,8 +64,13 @@
 }
 
 .snipsidian-preview-table td:nth-child(1) { width: 20%; } /* Trigger */
-.snipsidian-preview-table td:nth-child(2) { width: 30%; } /* Current */
-.snipsidian-preview-table td:nth-child(3) { width: 30%; } /* Incoming */
+.snipsidian-preview-table td:nth-child(2),
+.snipsidian-preview-table td:nth-child(3) {
+  width: 30%; /* Current / Incoming */
+  font-family: var(--font-monospace);
+  white-space: pre-wrap;
+  font-size: 0.8em;
+}
 .snipsidian-preview-table td:nth-child(4) { width: 20%; } /* Action */
 
 .snipsidian-preview-table th {
@@ -87,13 +81,6 @@
 
 .snipsidian-preview-table tr:hover td {
   background: var(--background-secondary);
-}
-
-.snipsidian-preview-table td:nth-child(2),
-.snipsidian-preview-table td:nth-child(3) {
-  font-family: var(--font-monospace);
-  white-space: pre-wrap;
-  font-size: 0.8em;
 }
 
 .snipsidian-preview-table .conflict-action select {
@@ -322,53 +309,7 @@
   border: 1px solid var(--background-modifier-border);
 }
 
-/* Package Details Modal */
-.package-details-info {
-  margin-bottom: var(--spacing-xl);
-}
-
-.package-details-info h3 {
-  margin: 0 0 10px 0;
-  color: var(--text-normal);
-}
-
-.package-details-info .package-description {
-  margin: 0 0 15px 0;
-  color: var(--text-muted);
-  line-height: 1.5;
-}
-
-.package-details-info .package-meta {
-  display: flex;
-  gap: var(--spacing-xl);
-  margin-bottom: 15px;
-  font-size: 14px;
-  color: var(--text-muted);
-}
-
-.package-details-info .package-tags {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 6px;
-}
-
-.package-details-info .package-tag {
-  background: var(--background-secondary);
-  color: var(--text-muted);
-  padding: 2px 8px;
-  border-radius: 12px;
-  font-size: 12px;
-}
-
-.package-snippets {
-  margin-top: var(--spacing-xl);
-}
-
-.package-snippets h4 {
-  margin: 0 0 15px 0;
-  color: var(--text-normal);
-}
-
+/* Package snippets table (kept here; modal/details rules live in sections/community.css and components/modals.css) */
 .snippets-table {
   width: 100%;
   border-collapse: collapse;
@@ -377,26 +318,21 @@
   overflow: hidden;
 }
 
-.snippets-table th,
-.snippets-table td {
+.snippets-table th {
   padding: var(--spacing-sm) var(--spacing-md);
   text-align: left;
   border-bottom: 1px solid var(--background-modifier-border);
   font-size: 13px;
-}
-
-.snippets-table th {
   background: var(--background-secondary);
   font-weight: 600;
   color: var(--text-normal);
 }
 
 .snippets-table td {
+  padding: var(--spacing-sm) var(--spacing-md);
+  text-align: left;
+  border-bottom: 1px solid var(--background-modifier-border);
+  font-size: 13px;
   color: var(--text-muted);
   font-family: var(--font-monospace);
-}
-
-.modal-button-container {
-  margin-top: var(--spacing-xl);
-  text-align: right;
 }

--- a/src/styles/sections/community.css
+++ b/src/styles/sections/community.css
@@ -1,4 +1,4 @@
-.snipsy-section{display:block;border:1px solid var(--background-modifier-border);border-radius:10px;padding:14px;background:var(--background-primary);margin-bottom:12px}
+/* .snipsy-section base lives in layout.css; section title/description and compact variants only */
 .section-title{margin:0 0 6px;font-size:14px;font-weight:600;color:var(--text-normal)}
 .section-description{margin:0;color:var(--text-muted);font-size:12px}
 .snipsy-compact .snipsy-section{padding:12px;margin-bottom:10px;border-radius:8px}
@@ -47,7 +47,7 @@
 .snipsy-community-browse-section .rating-btn:hover{opacity:1;background:var(--background-secondary)}
 .snipsy-community-browse-section .rating-value{font-weight:600;color:var(--text-normal);min-width:20px;text-align:center}
 .snipsy-community-browse-section .package-actions-cell{text-align:center}
-.snipsy-community-browse-section .install-btn{background:var(--color-green);color:#fff;border:none;padding:6px 12px;border-radius:6px;font-size:13px;font-weight:500;cursor:pointer}
+.snipsy-community-browse-section .install-btn{background:var(--color-green);color:#ffffff;border:none;padding:6px 12px;border-radius:6px;font-size:13px;font-weight:500;cursor:pointer}
 .snipsy-community-browse-section .install-btn.installed{background:var(--background-secondary);color:var(--text-muted);cursor:default}
 .snipsy-community-browse-section .install-btn.installed:disabled{opacity:1}
 
@@ -72,10 +72,8 @@
 .snipsy-espanso-section .yaml-input-row{margin:0 0 10px}
 .snipsy-community-submit-section .yaml-instruction,
 .snipsy-espanso-section .yaml-instruction{margin:0 0 8px;color:var(--text-muted);font-size:12.5px}
-.snipsy-community-submit-section .yaml-textarea,
-.snipsy-espanso-section .yaml-textarea{width:100%;padding:10px;border:1px solid var(--background-modifier-border);border-radius:8px;background:var(--background-primary);color:var(--text-normal);font-family:var(--font-monospace);font-size:12.5px;line-height:1.4;resize:vertical;box-sizing:border-box}
-.snipsy-community-submit-section .yaml-textarea{min-height:180px;max-height:360px;height:200px}
-.snipsy-espanso-section .yaml-textarea{min-height:120px;max-height:300px;height:120px}
+.snipsy-community-submit-section .yaml-textarea{width:100%;padding:10px;border:1px solid var(--background-modifier-border);border-radius:8px;background:var(--background-primary);color:var(--text-normal);font-family:var(--font-monospace);font-size:12.5px;line-height:1.4;resize:vertical;box-sizing:border-box;min-height:180px;max-height:360px;height:200px}
+.snipsy-espanso-section .yaml-textarea{width:100%;padding:10px;border:1px solid var(--background-modifier-border);border-radius:8px;background:var(--background-primary);color:var(--text-normal);font-family:var(--font-monospace);font-size:12.5px;line-height:1.4;resize:vertical;box-sizing:border-box;min-height:120px;max-height:300px;height:120px}
 .snipsy-submit-modal .yaml-textarea{min-height:180px;max-height:360px;height:200px}
 .snipsy-community-submit-section .validation-container{min-height:0}
 .snipsy-community-submit-section .validation-success,
@@ -83,17 +81,14 @@
 .snipsy-community-submit-section .validation-title{font-weight:600;margin-bottom:6px}
 .snipsy-community-submit-section .button-row,
 .snipsy-espanso-section .button-row{display:flex;gap:8px;justify-content:flex-end;margin-top:8px;padding-top:8px;border-top:1px solid var(--background-modifier-border)}
-.snipsy-community-submit-section .validate-btn,
-.snipsy-community-submit-section .submit-btn,
-.snipsy-espanso-section .install-btn{border:none;padding:6px 12px;border-radius:6px;font-size:13px;font-weight:500;cursor:pointer}
-.snipsy-community-submit-section .validate-btn{background:var(--color-blue);color:#fff}
-.snipsy-community-submit-section .submit-btn,
-.snipsy-espanso-section .install-btn{background:var(--color-green);color:#fff}
+.snipsy-community-submit-section .validate-btn{border:none;padding:6px 12px;border-radius:6px;font-size:13px;font-weight:500;cursor:pointer;background:var(--color-blue);color:#ffffff}
+.snipsy-community-submit-section .submit-btn{border:none;padding:6px 12px;border-radius:6px;font-size:13px;font-weight:500;cursor:pointer;background:var(--color-green);color:#ffffff}
+.snipsy-espanso-section .install-btn{border:none;padding:6px 12px;border-radius:6px;font-size:13px;font-weight:500;cursor:pointer;background:var(--color-green);color:#ffffff}
 .snipsy-community-submit-section .submit-btn:disabled{background:var(--background-secondary);color:var(--text-muted);cursor:not-allowed;opacity:.6}
 
 /* Package Details Modal */
-.package-details-info h3{margin:0 0 12px 0;color:var(--text-normal);font-size:18px;font-weight:600}
-.package-details-info .package-description{margin:0 0 16px 0;color:var(--text-muted);font-size:14px;line-height:1.5}
+.package-details-info h3{margin:0 0 12px;color:var(--text-normal);font-size:18px;font-weight:600}
+.package-details-info .package-description{margin:0 0 16px;color:var(--text-muted);font-size:14px;line-height:1.5}
 .package-details-info .package-meta{display:flex;flex-direction:column;gap:8px;margin-top:16px}
 .package-details-info .package-meta div{margin:4px 0;color:var(--text-normal);font-size:14px}
 .package-details-info .package-tags{margin-top:16px}
@@ -101,7 +96,7 @@
 .package-details-info .package-tags-list{display:flex;flex-wrap:wrap;gap:4px}
 .package-details-info .package-tags span{display:inline-block;background:var(--background-secondary);color:var(--text-normal);padding:2px 6px;border-radius:4px;font-size:12px}
 .package-details-info .snippets-label{font-weight:600;margin-bottom:8px;margin-top:16px}
-.package-details-info .modal-button-container{display:flex;gap:12px;justify-content:flex-end;margin-top:16px}
+/* .package-details-info .modal-button-container lives in components/modals.css */
 
 /* Snippets in modal */
 .package-details-info .package-snippets{margin-top:16px}

--- a/src/test/stubs/obsidian.ts
+++ b/src/test/stubs/obsidian.ts
@@ -47,13 +47,12 @@ export const Platform = {
     isWin: false,
     isLinux: false
 };
-// eslint-disable-next-line @typescript-eslint/no-unused-vars -- Parameter kept for API compatibility
-export class Notice { constructor(_msg: string) { 
+export class Notice { constructor(_msg: string) {
     // _msg parameter kept for API compatibility but not used in test stub
 } }
-export class Modal { 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unused-vars -- Test stub constructor, parameter kept for API compatibility
-    constructor(_app: any) { 
+export class Modal {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Test stub constructor, parameter kept for API compatibility
+    constructor(_app: any) {
     // _app parameter kept for API compatibility but not used in test stub
 }
     open() { }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,17 @@
 import type { PackageItem } from "./services/community-packages";
 
+// Augment Obsidian's App type with internal APIs we rely on. These exist at
+// runtime but aren't part of the public obsidian.d.ts.
+declare module "obsidian" {
+    interface App {
+        setting: {
+            open(): void;
+            openTabById(id: string): void;
+        };
+        version: string;
+    }
+}
+
 export interface SnipSidianSettings {
     snippets: Record<string, string>;
     ui?: {

--- a/src/ui/components/BasicTab.ts
+++ b/src/ui/components/BasicTab.ts
@@ -31,13 +31,11 @@ export class BasicTab {
                     .setCta()
                     .onClick(() => {
                         // Open hotkey settings for the insert-snippet command
-                        // @ts-expect-error - Obsidian API works correctly at runtime
                         this.app.setting.open();
-                        // @ts-expect-error - Obsidian API works correctly at runtime
                         this.app.setting.openTabById("hotkeys");
                         // Focus on our command
-                        setTimeout(() => {
-                            const hotkeyTab = document.querySelector('.setting-item[data-id="snipsidian:insert-snippet"]');
+                        activeWindow.setTimeout(() => {
+                            const hotkeyTab = activeDocument.querySelector('.setting-item[data-id="snipsidian:insert-snippet"]');
                             if (hotkeyTab) {
                                 hotkeyTab.scrollIntoView({ behavior: 'smooth', block: 'center' });
                             }
@@ -54,13 +52,11 @@ export class BasicTab {
                     .setCta()
                     .onClick(() => {
                         // Open hotkey settings for the open-settings command
-                        // @ts-expect-error - Obsidian API works correctly at runtime
                         this.app.setting.open();
-                        // @ts-expect-error - Obsidian API works correctly at runtime
                         this.app.setting.openTabById("hotkeys");
                         // Focus on our command
-                        setTimeout(() => {
-                            const hotkeyTab = document.querySelector('.setting-item[data-id="snipsidian:open-settings"]');
+                        activeWindow.setTimeout(() => {
+                            const hotkeyTab = activeDocument.querySelector('.setting-item[data-id="snipsidian:open-settings"]');
                             if (hotkeyTab) {
                                 hotkeyTab.scrollIntoView({ behavior: 'smooth', block: 'center' });
                             }
@@ -82,7 +78,7 @@ export class BasicTab {
                         const data = JSON.stringify(this.plugin.settings.snippets, null, 2);
                         const blob = new Blob([data], { type: "application/json" });
                         const url = URL.createObjectURL(blob);
-                        const a = document.createElement("a");
+                        const a = createEl("a");
                         a.href = url;
                         a.download = "snipsidian-snippets.json";
                         a.click();
@@ -98,7 +94,7 @@ export class BasicTab {
                     .setButtonText("Import JSON")
                     .setCta()
                     .onClick(() => {
-                        const input = document.createElement("input");
+                        const input = createEl("input");
                         input.type = "file";
                         input.accept = ".json";
                         input.onchange = async (e) => {
@@ -107,7 +103,7 @@ export class BasicTab {
 
                             try {
                                 const text = await file.text();
-                                const parsed = JSON.parse(text);
+                                const parsed: unknown = JSON.parse(text);
                                 if (!isRecordOfString(parsed)) {
                                     new Notice("Invalid JSON: must be an object of { trigger: replacement } strings");
                                     return;

--- a/src/ui/components/Modals.ts
+++ b/src/ui/components/Modals.ts
@@ -236,14 +236,14 @@ export class TextPromptModal extends Modal {
                 const v = (this.value ?? "").trim();
                 if (!v) {
                     err.empty();
-                    err.createEl("span", { text: "Value cannot be empty." });
+                    err.createSpan({ text: "Value cannot be empty." });
                     return;
                 }
                 if (this.opts.validate) {
                     const msg = this.opts.validate(v);
                     if (msg) {
                         err.empty();
-                        err.createEl("span", { text: msg });
+                        err.createSpan({ text: msg });
                         return;
                     }
                 }

--- a/src/ui/components/SnippetPickerModal.ts
+++ b/src/ui/components/SnippetPickerModal.ts
@@ -48,14 +48,14 @@ export class SnippetPickerModal extends Modal {
         const hints = contentEl.createDiv("snippet-hints");
         
         hints.createEl("strong", { text: "Navigation:" });
-        hints.appendChild(document.createTextNode(" ↑/↓ to navigate, "));
+        hints.appendChild(activeDocument.createTextNode(" ↑/↓ to navigate, "));
         hints.createEl("strong", { text: "Enter" });
-        hints.appendChild(document.createTextNode(" to insert, "));
+        hints.appendChild(activeDocument.createTextNode(" to insert, "));
         hints.createEl("strong", { text: "Esc" });
-        hints.appendChild(document.createTextNode(" to close"));
+        hints.appendChild(activeDocument.createTextNode(" to close"));
         hints.createEl("br");
         hints.createEl("strong", { text: "Click" });
-        hints.appendChild(document.createTextNode(" any snippet to insert it directly"));
+        hints.appendChild(activeDocument.createTextNode(" any snippet to insert it directly"));
 
         // Event handlers
         this.setupEventHandlers();
@@ -70,9 +70,9 @@ export class SnippetPickerModal extends Modal {
     onClose(): void {
         const { contentEl } = this;
         contentEl.empty();
-        
+
         if (this.searchTimeout) {
-            clearTimeout(this.searchTimeout);
+            activeWindow.clearTimeout(this.searchTimeout);
         }
     }
 
@@ -80,10 +80,10 @@ export class SnippetPickerModal extends Modal {
         // Search with debounce
         this.searchInput.addEventListener("input", () => {
             if (this.searchTimeout) {
-                clearTimeout(this.searchTimeout);
+                activeWindow.clearTimeout(this.searchTimeout);
             }
-            
-            this.searchTimeout = window.setTimeout(() => {
+
+            this.searchTimeout = activeWindow.setTimeout(() => {
                 this.performSearch(this.searchInput.value);
             }, this.debounceMs);
         });
@@ -140,7 +140,7 @@ export class SnippetPickerModal extends Modal {
 
         if (this.searchResults.length === 0) {
             const emptyState = this.resultsList.createDiv("empty-state");
-            emptyState.createEl("span", { text: "No snippets found" });
+            emptyState.createSpan({ text: "No snippets found" });
             return;
         }
 
@@ -150,18 +150,18 @@ export class SnippetPickerModal extends Modal {
 
             // Name (trigger)
             const name = item.createDiv("snippet-name");
-            name.createEl("span", { text: snippet.trigger });
+            name.createSpan({ text: snippet.trigger });
 
             // Folder
             const folder = item.createDiv("snippet-folder");
-            folder.createEl("span", { text: `(${snippet.folder})` });
+            folder.createSpan({ text: `(${snippet.folder})` });
 
             // Preview (first characters)
             const preview = item.createDiv("snippet-preview-text");
-            const previewText = snippet.replacement.length > 50 
-                ? snippet.replacement.substring(0, 50) + "..." 
+            const previewText = snippet.replacement.length > 50
+                ? snippet.replacement.substring(0, 50) + "..."
                 : snippet.replacement;
-            preview.createEl("span", { text: previewText });
+            preview.createSpan({ text: previewText });
 
             // Click to select
             item.addEventListener("click", (e) => {
@@ -219,9 +219,9 @@ export class SnippetPickerModal extends Modal {
             const metaDiv = this.previewDiv.createDiv("snippet-preview-meta");
             
             metaDiv.createEl("strong", { text: "Trigger:" });
-            metaDiv.appendChild(document.createTextNode(` ${selectedSnippet.trigger} | `));
+            metaDiv.appendChild(activeDocument.createTextNode(` ${selectedSnippet.trigger} | `));
             metaDiv.createEl("strong", { text: "Folder:" });
-            metaDiv.appendChild(document.createTextNode(` ${selectedSnippet.folder}`));
+            metaDiv.appendChild(activeDocument.createTextNode(` ${selectedSnippet.folder}`));
             
             // Create preview text with highlighting
             const previewTextDiv = this.previewDiv.createDiv("snippet-preview-text-container");
@@ -277,25 +277,25 @@ export class SnippetPickerModal extends Modal {
             for (const marker of markers) {
                 // Add text before marker
                 if (marker.index > lastIndex) {
-                    previewTextDiv.appendChild(document.createTextNode(text.substring(lastIndex, marker.index)));
+                    previewTextDiv.appendChild(activeDocument.createTextNode(text.substring(lastIndex, marker.index)));
                 }
-                
+
                 // Add highlighted marker
-                previewTextDiv.createEl("span", {
+                previewTextDiv.createSpan({
                     cls: marker.type === 'cursor' ? "snippet-highlight-cursor" : "snippet-highlight-tabstop",
                     text: marker.text
                 });
-                
+
                 lastIndex = marker.index + marker.length;
             }
-            
+
             // Add remaining text
             if (lastIndex < text.length) {
-                previewTextDiv.appendChild(document.createTextNode(text.substring(lastIndex)));
+                previewTextDiv.appendChild(activeDocument.createTextNode(text.substring(lastIndex)));
             }
         } else {
             const emptyDiv = this.previewDiv.createDiv("snippet-preview-empty");
-            emptyDiv.createEl("span", { text: "Select a snippet to preview" });
+            emptyDiv.createSpan({ text: "Select a snippet to preview" });
         }
     }
 

--- a/src/ui/components/SnippetsTab.ts
+++ b/src/ui/components/SnippetsTab.ts
@@ -190,7 +190,7 @@ export class SnippetsTab {
             };
 
             // Group title
-            header.createEl("span", { text: title, cls: "group-title" });
+            header.createSpan({ text: title, cls: "group-title" });
 
             // Group actions
             const actions = header.createDiv({ cls: "group-actions" });
@@ -303,7 +303,7 @@ export class SnippetsTab {
                     editBtn.onclick = () => {
                         if (isEditing) {
                             // Save changes
-                            const root = document.querySelector('.snipsidian-settings');
+                            const root = activeDocument.querySelector('.snipsidian-settings');
                             if (root) {
                                 void this.saveSnippetChanges(row, trigger, triggerName, replacement, root as HTMLElement);
                             }
@@ -468,7 +468,7 @@ export class SnippetsTab {
                 await this.plugin.saveSettings();
                 
                 // Refresh the list
-                const root = document.querySelector('.snipsidian-settings');
+                const root = activeDocument.querySelector('.snipsidian-settings');
                 if (root) {
                     this.renderSnippetList(root as HTMLElement);
                 }
@@ -516,7 +516,7 @@ export class SnippetsTab {
         
         // Update edit button
         editBtn.empty();
-        editBtn.createEl("span", { text: "💾" });
+        editBtn.createSpan({ text: "💾" });
         editBtn.title = "Save changes";
         
         // Store references for save/cancel
@@ -533,7 +533,7 @@ export class SnippetsTab {
         
         // Add event handlers
         saveBtn.onclick = () => {
-            const root = document.querySelector('.snipsidian-settings');
+            const root = activeDocument.querySelector('.snipsidian-settings');
             if (root) {
                 void this.saveSnippetChanges(row, trigger, triggerName, replacement, root as HTMLElement);
             }
@@ -544,7 +544,7 @@ export class SnippetsTab {
         };
     }
 
-    private async saveSnippetChanges(row: Setting, originalTrigger: string, originalTriggerName: string, originalReplacement: string, root: HTMLElement) {
+    private async saveSnippetChanges(row: Setting, originalTrigger: string, _originalTriggerName: string, _originalReplacement: string, root: HTMLElement) {
         const editData = (row as SettingWithEditData).editData;
         if (!editData) return;
         
@@ -602,14 +602,14 @@ export class SnippetsTab {
     private cancelEditMode(row: Setting, editBtn: HTMLButtonElement) {
         // Reset edit button
         editBtn.empty();
-        editBtn.createEl("span", { text: "✏️" });
+        editBtn.createSpan({ text: "✏️" });
         editBtn.title = "Edit snippet";
         
         // Clear edit data
         delete (row as SettingWithEditData).editData;
         
         // Re-render the snippet list to return to normal view
-        const root = document.querySelector('.snipsidian-settings') as HTMLElement;
+        const root = activeDocument.querySelector('.snipsidian-settings') as HTMLElement;
         if (root) {
             this.renderSnippetList(root);
         }

--- a/src/ui/components/SubmitPackageModal.ts
+++ b/src/ui/components/SubmitPackageModal.ts
@@ -3,7 +3,7 @@ import type SnipSidianPlugin from "../../main";
 import { validatePackage, type ValidationResult } from "../../services/package-validator";
 import { processPackageSubmission } from "../../services/community-packages";
 import type { PackageData } from "../../services/package-types";
-import * as yaml from "js-yaml";
+import * as YAML from "yaml";
 
 export class SubmitPackageModal extends Modal {
     private yamlTextarea!: HTMLTextAreaElement;
@@ -90,7 +90,7 @@ export class SubmitPackageModal extends Modal {
         }
 
         try {
-            const packageData = yaml.load(yamlContent);
+            const packageData = YAML.parse(yamlContent);
             
             if (!packageData || typeof packageData !== 'object') {
                 this.showValidationResult({
@@ -134,19 +134,19 @@ export class SubmitPackageModal extends Modal {
 
         if (validation.isValid) {
             const successEl = this.validationContainer.createDiv({ cls: "validation-success" });
-            successEl.createEl("div", { 
+            successEl.createDiv({
                 text: "Package is valid!",
                 cls: "validation-title"
             });
-            
+
             if (validation.warnings.length > 0) {
                 const warningsEl = successEl.createDiv({ cls: "validation-warnings" });
-                warningsEl.createEl("div", { 
+                warningsEl.createDiv({
                     text: "Warnings:",
                     cls: "warnings-title"
                 });
                 validation.warnings.forEach((warning: string) => {
-                    warningsEl.createEl("div", { 
+                    warningsEl.createDiv({
                         text: warning,
                         cls: "warning-item"
                     });
@@ -154,13 +154,13 @@ export class SubmitPackageModal extends Modal {
             }
         } else {
             const errorEl = this.validationContainer.createDiv({ cls: "validation-error" });
-            errorEl.createEl("div", { 
+            errorEl.createDiv({
                 text: "Validation failed:",
                 cls: "validation-title"
             });
-            
+
             validation.errors.forEach((error: string) => {
-                errorEl.createEl("div", { 
+                errorEl.createDiv({
                     text: `• ${error}`,
                     cls: "error-item"
                 });
@@ -176,7 +176,7 @@ export class SubmitPackageModal extends Modal {
 
         try {
             const yamlContent = this.yamlTextarea.value.trim();
-            const packageData = yaml.load(yamlContent) as PackageData;
+            const packageData = YAML.parse(yamlContent) as PackageData;
             
             // Generate a temporary filename
             const packageId = this.generatePackageId(packageData.name || '');
@@ -190,7 +190,7 @@ export class SubmitPackageModal extends Modal {
                 this.showSuccessMessage();
                 
                 // Close modal after a delay
-                setTimeout(() => {
+                activeWindow.setTimeout(() => {
                     this.close();
                 }, 3000);
             } else {
@@ -205,11 +205,11 @@ export class SubmitPackageModal extends Modal {
         this.validationContainer.empty();
         
         const successEl = this.validationContainer.createDiv({ cls: "submission-success" });
-        successEl.createEl("div", { 
+        successEl.createDiv({
             text: "Thank you for contributing to the community!",
             cls: "success-title"
         });
-        successEl.createEl("div", { 
+        successEl.createDiv({
             text: "Your package has been submitted for review and will appear in the pending packages.",
             cls: "success-message"
         });

--- a/src/ui/components/community/PackageBrowser.ts
+++ b/src/ui/components/community/PackageBrowser.ts
@@ -250,7 +250,7 @@ export class PackageBrowser {
       const installedCount = Object.keys(pkg.snippets || {}).length;
       new Notice(`Successfully installed "${pkg.label}" with ${installedCount} snippets`);
 
-      const browseSection = document.querySelector(".snipsy-community-browse-section");
+      const browseSection = activeDocument.querySelector(".snipsy-community-browse-section");
       if (browseSection) this.renderPackages(browseSection as HTMLElement);
     } catch (error) {
       new Notice(`Failed to install package: ${error instanceof Error ? error.message : String(error)}`);
@@ -278,7 +278,7 @@ export class PackageBrowser {
       new Notice(`Successfully installed "${pkg.label}" with ${installedCount} snippets in group "${packageGroup}"`);
       
       // Re-render to update the "Installed" status
-      const browseSection = document.querySelector(".snipsy-community-browse-section");
+      const browseSection = activeDocument.querySelector(".snipsy-community-browse-section");
       if (browseSection) this.renderPackages(browseSection as HTMLElement);
       
     } catch (error) {
@@ -331,12 +331,12 @@ export class PackageBrowser {
 
     // Update header classes and re-render
     this.updateSortHeaders();
-    const browseSection = document.querySelector(".snipsy-community-browse-section");
+    const browseSection = activeDocument.querySelector(".snipsy-community-browse-section");
     if (browseSection) this.renderPackages(browseSection as HTMLElement);
   }
 
   private updateSortHeaders() {
-    const headers = document.querySelectorAll('.packages-table th.sortable');
+    const headers = activeDocument.querySelectorAll('.packages-table th.sortable');
     headers.forEach(header => {
       header.classList.remove('sort-asc', 'sort-desc');
       const text = header.textContent?.trim();
@@ -360,49 +360,49 @@ export class PackageBrowser {
     
     if (pkg.verified) {
        
-      infoSection.createEl("span", { text: "Verified", cls: "verified-badge" });
+      infoSection.createSpan({ text: "Verified", cls: "verified-badge" });
     }
-    
+
     if (pkg.description) {
       infoSection.createEl("p", { text: pkg.description, cls: "package-description" });
     }
-    
+
     const meta = infoSection.createDiv({ cls: "package-meta" });
-    
-    meta.createEl("div", { text: `Author: ${pkg.author || "Unknown"}` });
-    meta.createEl("div", { text: `Version: ${pkg.version || "1.0.0"}` });
-    
+
+    meta.createDiv({ text: `Author: ${pkg.author || "Unknown"}` });
+    meta.createDiv({ text: `Version: ${pkg.version || "1.0.0"}` });
+
     if (pkg.tags && pkg.tags.length > 0) {
       const tagsContainer = infoSection.createDiv({ cls: "package-tags" });
-      tagsContainer.createEl("div", { text: "Tags:", cls: "package-tags-label" });
+      tagsContainer.createDiv({ text: "Tags:", cls: "package-tags-label" });
       const tagsList = tagsContainer.createDiv({ cls: "package-tags-list" });
-      
+
       pkg.tags.forEach(tag => {
-        tagsList.createEl("span", { text: tag });
+        tagsList.createSpan({ text: tag });
       });
     }
-    
+
     // Add snippets section
     if (pkg.snippets && Object.keys(pkg.snippets).length > 0) {
       const snippetsContainer = infoSection.createDiv({ cls: "package-snippets" });
-      snippetsContainer.createEl("div", { 
+      snippetsContainer.createDiv({
         text: `Snippets (${Object.keys(pkg.snippets).length}):`,
         cls: "snippets-label"
       });
-      
+
       const snippetsList = snippetsContainer.createDiv({ cls: "snippets-list" });
-      
+
       Object.entries(pkg.snippets).forEach(([trigger, replacement]) => {
         const snippetRow = snippetsList.createDiv({ cls: "snippet-row" });
-        
+
         const triggerEl = snippetRow.createDiv({ cls: "snippet-trigger" });
-        triggerEl.createEl("span", { text: trigger });
-        
+        triggerEl.createSpan({ text: trigger });
+
         const arrowEl = snippetRow.createDiv({ cls: "snippet-arrow" });
-        arrowEl.createEl("span", { text: "→" });
-        
+        arrowEl.createSpan({ text: "→" });
+
         const replacementEl = snippetRow.createDiv({ cls: "snippet-replacement" });
-        replacementEl.createEl("span", { text: replacement });
+        replacementEl.createSpan({ text: replacement });
         replacementEl.title = replacement; // Show full text on hover
       });
     }
@@ -438,7 +438,7 @@ export class PackageBrowser {
     const endItem = Math.min(this.currentPage * this.itemsPerPage, this.filteredPackages.length);
     const totalItems = this.filteredPackages.length;
     
-    paginationContainer.createEl("span", {
+    paginationContainer.createSpan({
       text: `Showing ${startItem}-${endItem} of ${totalItems} packages`,
       cls: "pagination-info"
     });
@@ -456,7 +456,7 @@ export class PackageBrowser {
     
     pages.forEach((page) => {
       if (page === '...') {
-        paginationContainer.createEl("span", {
+        paginationContainer.createSpan({
           text: "...",
           cls: "pagination-ellipsis"
         });
@@ -526,7 +526,7 @@ export class PackageBrowser {
     const totalPages = Math.ceil(this.filteredPackages.length / this.itemsPerPage);
     if (page >= 1 && page <= totalPages) {
       this.currentPage = page;
-      const browseSection = document.querySelector(".snipsy-community-browse-section");
+      const browseSection = activeDocument.querySelector(".snipsy-community-browse-section");
       if (browseSection) this.renderPackages(browseSection as HTMLElement);
     }
   }

--- a/src/ui/components/community/PackageSubmissionSection.ts
+++ b/src/ui/components/community/PackageSubmissionSection.ts
@@ -3,7 +3,7 @@ import type SnipSidianPlugin from "../../../main";
 import { validatePackage, type ValidationResult } from "../../../services/package-validator";
 import { openPackageSubmissionForm } from "../../../services/package-submission-form";
 import type { PackageData } from "../../../services/package-types";
-import * as yaml from "js-yaml";
+import * as YAML from "yaml";
 
 export class PackageSubmissionSection {
   private validationResult: ValidationResult | null = null;
@@ -58,7 +58,7 @@ export class PackageSubmissionSection {
       return;
     }
     try {
-      const packageData = yaml.load(yamlContent) as PackageData;
+      const packageData = YAML.parse(yamlContent) as PackageData;
       if (!packageData || typeof packageData !== "object") {
         this.showValidationResult(container, { isValid: false, errors: ["Invalid YAML format"], warnings: [] });
         return;
@@ -85,25 +85,25 @@ export class PackageSubmissionSection {
     container.empty();
     if (validation.isValid) {
       const successEl = container.createDiv({ cls: "validation-success" });
-      successEl.createEl("div", { 
-          text: "Package is valid!", 
-          cls: "validation-title" 
+      successEl.createDiv({
+          text: "Package is valid!",
+          cls: "validation-title"
       });
       if (validation.warnings.length > 0) {
         const warningsEl = successEl.createDiv({ cls: "validation-warnings" });
-        warningsEl.createEl("div", { 
-            text: "Warnings:", 
-            cls: "warnings-title" 
+        warningsEl.createDiv({
+            text: "Warnings:",
+            cls: "warnings-title"
         });
-        validation.warnings.forEach((w: string) => warningsEl.createEl("div", { text: w, cls: "warning-item" }));
+        validation.warnings.forEach((w: string) => warningsEl.createDiv({ text: w, cls: "warning-item" }));
       }
     } else {
       const errorEl = container.createDiv({ cls: "validation-error" });
-      errorEl.createEl("div", { 
-          text: "Validation failed:", 
-          cls: "validation-title" 
+      errorEl.createDiv({
+          text: "Validation failed:",
+          cls: "validation-title"
       });
-      validation.errors.forEach((e: string) => errorEl.createEl("div", { text: `• ${e}`, cls: "error-item" }));
+      validation.errors.forEach((e: string) => errorEl.createDiv({ text: `• ${e}`, cls: "error-item" }));
     }
   }
 
@@ -115,7 +115,7 @@ export class PackageSubmissionSection {
     
     try {
       const yamlContent = textarea.value.trim();
-      const packageData = yaml.load(yamlContent) as PackageData;
+      const packageData = YAML.parse(yamlContent) as PackageData;
       const result = openPackageSubmissionForm(
         packageData as Record<string, unknown>,
         this.app,

--- a/styles.css
+++ b/styles.css
@@ -58,8 +58,11 @@
   box-sizing: border-box;
 }
 
-/* Text overflow and horizontal scroll fixes */
+/* Text overflow and horizontal scroll fixes + heading rhythm vars */
 .mod-settings .snipsidian-settings {
+  --snip-h2-mb: 6px;
+  --snip-h3-mt: 18px;
+  --snip-h3-mb: 6px;
   overflow-x: hidden;
   word-wrap: break-word;
   word-break: break-word;
@@ -67,6 +70,8 @@
 
 .mod-settings .snipsidian-settings .setting-item {
   overflow-x: hidden;
+  padding-top: 8px;
+  padding-bottom: 8px;
 }
 
 .mod-settings .snipsidian-settings .setting-item-name {
@@ -138,19 +143,19 @@
   gap: 8px; 
 }
 
-.snipsidian-group-checkbox { 
-  margin-left: 4px; 
-}
-
-.snipsidian-row-checkbox { 
-  margin-right: 8px; 
-}
-
-.snipsidian-row-checkbox,
 .snipsidian-group-checkbox {
-  appearance: checkbox; 
+  margin-left: 4px;
+  appearance: checkbox;
   -webkit-appearance: checkbox;
-  width: 14px; 
+  width: 14px;
+  height: 14px;
+}
+
+.snipsidian-row-checkbox {
+  margin-right: 8px;
+  appearance: checkbox;
+  -webkit-appearance: checkbox;
+  width: 14px;
   height: 14px;
 }
 
@@ -630,7 +635,7 @@
 }
 
 .contact-section h3 {
-  margin: 0 0 var(--spacing-md) 0;
+  margin: 0 0 var(--spacing-md);
   color: var(--text-normal);
   font-size: 16px;
   font-weight: 600;
@@ -873,10 +878,10 @@
 /* ============ Modal Components ============ */
 
 /* Modal base styles */
-.modal .snipsidian-modal {
+.modal .snipsidian-modal.snipsidian-modal {
   width: min(500px, 90vw);
   max-width: 90vw;
-  overflow-x: hidden !important;
+  overflow-x: hidden;
 }
 
 .modal .snipsidian-modal * {
@@ -884,8 +889,8 @@
 }
 
 /* Kill horizontal scroll on Obsidian modal wrapper - only for our modals */
-.modal .snipsidian-modal .modal-content { 
-  overflow-x: hidden !important; 
+.modal .snipsidian-modal.snipsidian-modal .modal-content {
+  overflow-x: hidden;
 }
 
 /* Modal title */
@@ -1126,7 +1131,7 @@
 
 
 /* 5. Sections - Стили для конкретных секций */
-.snipsy-section{display:block;border:1px solid var(--background-modifier-border);border-radius:10px;padding:14px;background:var(--background-primary);margin-bottom:12px}
+/* .snipsy-section base lives in layout.css; section title/description and compact variants only */
 .section-title{margin:0 0 6px;font-size:14px;font-weight:600;color:var(--text-normal)}
 .section-description{margin:0;color:var(--text-muted);font-size:12px}
 .snipsy-compact .snipsy-section{padding:12px;margin-bottom:10px;border-radius:8px}
@@ -1175,7 +1180,7 @@
 .snipsy-community-browse-section .rating-btn:hover{opacity:1;background:var(--background-secondary)}
 .snipsy-community-browse-section .rating-value{font-weight:600;color:var(--text-normal);min-width:20px;text-align:center}
 .snipsy-community-browse-section .package-actions-cell{text-align:center}
-.snipsy-community-browse-section .install-btn{background:var(--color-green);color:#fff;border:none;padding:6px 12px;border-radius:6px;font-size:13px;font-weight:500;cursor:pointer}
+.snipsy-community-browse-section .install-btn{background:var(--color-green);color:#ffffff;border:none;padding:6px 12px;border-radius:6px;font-size:13px;font-weight:500;cursor:pointer}
 .snipsy-community-browse-section .install-btn.installed{background:var(--background-secondary);color:var(--text-muted);cursor:default}
 .snipsy-community-browse-section .install-btn.installed:disabled{opacity:1}
 
@@ -1200,10 +1205,8 @@
 .snipsy-espanso-section .yaml-input-row{margin:0 0 10px}
 .snipsy-community-submit-section .yaml-instruction,
 .snipsy-espanso-section .yaml-instruction{margin:0 0 8px;color:var(--text-muted);font-size:12.5px}
-.snipsy-community-submit-section .yaml-textarea,
-.snipsy-espanso-section .yaml-textarea{width:100%;padding:10px;border:1px solid var(--background-modifier-border);border-radius:8px;background:var(--background-primary);color:var(--text-normal);font-family:var(--font-monospace);font-size:12.5px;line-height:1.4;resize:vertical;box-sizing:border-box}
-.snipsy-community-submit-section .yaml-textarea{min-height:180px;max-height:360px;height:200px}
-.snipsy-espanso-section .yaml-textarea{min-height:120px;max-height:300px;height:120px}
+.snipsy-community-submit-section .yaml-textarea{width:100%;padding:10px;border:1px solid var(--background-modifier-border);border-radius:8px;background:var(--background-primary);color:var(--text-normal);font-family:var(--font-monospace);font-size:12.5px;line-height:1.4;resize:vertical;box-sizing:border-box;min-height:180px;max-height:360px;height:200px}
+.snipsy-espanso-section .yaml-textarea{width:100%;padding:10px;border:1px solid var(--background-modifier-border);border-radius:8px;background:var(--background-primary);color:var(--text-normal);font-family:var(--font-monospace);font-size:12.5px;line-height:1.4;resize:vertical;box-sizing:border-box;min-height:120px;max-height:300px;height:120px}
 .snipsy-submit-modal .yaml-textarea{min-height:180px;max-height:360px;height:200px}
 .snipsy-community-submit-section .validation-container{min-height:0}
 .snipsy-community-submit-section .validation-success,
@@ -1211,17 +1214,14 @@
 .snipsy-community-submit-section .validation-title{font-weight:600;margin-bottom:6px}
 .snipsy-community-submit-section .button-row,
 .snipsy-espanso-section .button-row{display:flex;gap:8px;justify-content:flex-end;margin-top:8px;padding-top:8px;border-top:1px solid var(--background-modifier-border)}
-.snipsy-community-submit-section .validate-btn,
-.snipsy-community-submit-section .submit-btn,
-.snipsy-espanso-section .install-btn{border:none;padding:6px 12px;border-radius:6px;font-size:13px;font-weight:500;cursor:pointer}
-.snipsy-community-submit-section .validate-btn{background:var(--color-blue);color:#fff}
-.snipsy-community-submit-section .submit-btn,
-.snipsy-espanso-section .install-btn{background:var(--color-green);color:#fff}
+.snipsy-community-submit-section .validate-btn{border:none;padding:6px 12px;border-radius:6px;font-size:13px;font-weight:500;cursor:pointer;background:var(--color-blue);color:#ffffff}
+.snipsy-community-submit-section .submit-btn{border:none;padding:6px 12px;border-radius:6px;font-size:13px;font-weight:500;cursor:pointer;background:var(--color-green);color:#ffffff}
+.snipsy-espanso-section .install-btn{border:none;padding:6px 12px;border-radius:6px;font-size:13px;font-weight:500;cursor:pointer;background:var(--color-green);color:#ffffff}
 .snipsy-community-submit-section .submit-btn:disabled{background:var(--background-secondary);color:var(--text-muted);cursor:not-allowed;opacity:.6}
 
 /* Package Details Modal */
-.package-details-info h3{margin:0 0 12px 0;color:var(--text-normal);font-size:18px;font-weight:600}
-.package-details-info .package-description{margin:0 0 16px 0;color:var(--text-muted);font-size:14px;line-height:1.5}
+.package-details-info h3{margin:0 0 12px;color:var(--text-normal);font-size:18px;font-weight:600}
+.package-details-info .package-description{margin:0 0 16px;color:var(--text-muted);font-size:14px;line-height:1.5}
 .package-details-info .package-meta{display:flex;flex-direction:column;gap:8px;margin-top:16px}
 .package-details-info .package-meta div{margin:4px 0;color:var(--text-normal);font-size:14px}
 .package-details-info .package-tags{margin-top:16px}
@@ -1229,7 +1229,7 @@
 .package-details-info .package-tags-list{display:flex;flex-wrap:wrap;gap:4px}
 .package-details-info .package-tags span{display:inline-block;background:var(--background-secondary);color:var(--text-normal);padding:2px 6px;border-radius:4px;font-size:12px}
 .package-details-info .snippets-label{font-weight:600;margin-bottom:8px;margin-top:16px}
-.package-details-info .modal-button-container{display:flex;gap:12px;justify-content:flex-end;margin-top:16px}
+/* .package-details-info .modal-button-container lives in components/modals.css */
 
 /* Snippets in modal */
 .package-details-info .package-snippets{margin-top:16px}
@@ -1251,13 +1251,7 @@
 /* ============ Legacy Styles (временно) ============ */
 /* Эти стили будут постепенно перенесены в модули */
 
-/* Settings panel (legacy bits) */
-.mod-settings .snipsidian-settings {
-  --snip-h2-mb: 6px;
-  --snip-h3-mt: 18px;
-  --snip-h3-mb: 6px;
-}
-
+/* Settings panel heading rhythm (vars + .setting-item padding live in base.css) */
 .mod-settings .snipsidian-settings h2 {
   margin-top: 0;
   margin-bottom: var(--snip-h2-mb);
@@ -1273,11 +1267,6 @@
 .mod-settings .snipsidian-settings h3 {
   margin-top: var(--snip-h3-mt);
   margin-bottom: var(--snip-h3-mb);
-}
-
-.mod-settings .snipsidian-settings .setting-item {
-  padding-top: 8px;
-  padding-bottom: 8px;
 }
 
 .mod-settings .snipsidian-settings h3 + .setting-item {
@@ -1305,8 +1294,13 @@
 }
 
 .snipsidian-preview-table td:nth-child(1) { width: 20%; } /* Trigger */
-.snipsidian-preview-table td:nth-child(2) { width: 30%; } /* Current */
-.snipsidian-preview-table td:nth-child(3) { width: 30%; } /* Incoming */
+.snipsidian-preview-table td:nth-child(2),
+.snipsidian-preview-table td:nth-child(3) {
+  width: 30%; /* Current / Incoming */
+  font-family: var(--font-monospace);
+  white-space: pre-wrap;
+  font-size: 0.8em;
+}
 .snipsidian-preview-table td:nth-child(4) { width: 20%; } /* Action */
 
 .snipsidian-preview-table th {
@@ -1317,13 +1311,6 @@
 
 .snipsidian-preview-table tr:hover td {
   background: var(--background-secondary);
-}
-
-.snipsidian-preview-table td:nth-child(2),
-.snipsidian-preview-table td:nth-child(3) {
-  font-family: var(--font-monospace);
-  white-space: pre-wrap;
-  font-size: 0.8em;
 }
 
 .snipsidian-preview-table .conflict-action select {
@@ -1552,53 +1539,7 @@
   border: 1px solid var(--background-modifier-border);
 }
 
-/* Package Details Modal */
-.package-details-info {
-  margin-bottom: var(--spacing-xl);
-}
-
-.package-details-info h3 {
-  margin: 0 0 10px 0;
-  color: var(--text-normal);
-}
-
-.package-details-info .package-description {
-  margin: 0 0 15px 0;
-  color: var(--text-muted);
-  line-height: 1.5;
-}
-
-.package-details-info .package-meta {
-  display: flex;
-  gap: var(--spacing-xl);
-  margin-bottom: 15px;
-  font-size: 14px;
-  color: var(--text-muted);
-}
-
-.package-details-info .package-tags {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 6px;
-}
-
-.package-details-info .package-tag {
-  background: var(--background-secondary);
-  color: var(--text-muted);
-  padding: 2px 8px;
-  border-radius: 12px;
-  font-size: 12px;
-}
-
-.package-snippets {
-  margin-top: var(--spacing-xl);
-}
-
-.package-snippets h4 {
-  margin: 0 0 15px 0;
-  color: var(--text-normal);
-}
-
+/* Package snippets table (kept here; modal/details rules live in sections/community.css and components/modals.css) */
 .snippets-table {
   width: 100%;
   border-collapse: collapse;
@@ -1607,26 +1548,21 @@
   overflow: hidden;
 }
 
-.snippets-table th,
-.snippets-table td {
+.snippets-table th {
   padding: var(--spacing-sm) var(--spacing-md);
   text-align: left;
   border-bottom: 1px solid var(--background-modifier-border);
   font-size: 13px;
-}
-
-.snippets-table th {
   background: var(--background-secondary);
   font-weight: 600;
   color: var(--text-normal);
 }
 
 .snippets-table td {
+  padding: var(--spacing-sm) var(--spacing-md);
+  text-align: left;
+  border-bottom: 1px solid var(--background-modifier-border);
+  font-size: 13px;
   color: var(--text-muted);
   font-family: var(--font-monospace);
-}
-
-.modal-button-container {
-  margin-top: var(--spacing-xl);
-  text-align: right;
 }


### PR DESCRIPTION
## Summary

Brings the codebase in line with the Obsidian community plugin scorecard at https://community.obsidian.md/plugins/snipsidian. After merge, the **Review** tab should drop from ~170 warnings → near-zero and **Health** should stay Excellent.

Three commits, each independently buildable:

1. **`chore: align with Obsidian community scorecard API rules`** — `document.*` → `activeDocument.*`, `setTimeout`/`clearTimeout` → `activeWindow.*`, `createEl("span"/"div")` → `createSpan`/`createDiv`, type `App.setting`/`App.version` via `declare module "obsidian"` (drops 4 `@ts-expect-error`), type GitHub API responses in `community-packages.ts`, prefix unused args with `_`, enable strict `@typescript-eslint/no-unused-vars` in `eslint.config.js`, and update the manifest description so it no longer starts with the plugin name.
2. **`style: consolidate stylesheet to clear scorecard CSS warnings`** — drop two `!important` overrides via class-doubled specificity, expand 3-digit hex literals, normalise trailing-zero margins, and de-duplicate selectors that lived in both `main.css` and `sections/community.css` (`.package-details-info` and friends, `.modal-button-container`, `.mod-settings .snipsidian-settings`).
3. **`build: migrate js-yaml -> yaml, harden dependencies, and update release workflow`** — replace `js-yaml` with Eemeli Aro's `yaml` across espanso/community/submission paths (mocks rewired), bump `esbuild` to `^0.28.0`, add npm `overrides` for transitively-flagged deps (`picomatch`/`minimatch`/`brace-expansion`/`js-yaml`/`glob`/`flatted`/`fast-uri`/`postcss`/`rollup`), stop attaching `snipsidian-*.zip` to the GitHub Release, and add `actions/attest-build-provenance@v2` for `main.js`/`manifest.json`/`styles.css`.

`npm audit` now reports **0 vulnerabilities**. No user-visible behavior changes — same commands, same data model, same UI flows.

## Test plan

- [x] `npm run lint` clean
- [x] `npx tsc --noEmit` clean
- [x] `npm test` → 242/242 passing
- [x] `npm run build` → `main.js` 175.9kb
- [x] `npm audit` → 0 vulnerabilities
- [ ] CI green on PR
- [ ] After merge: open Obsidian, verify the snippet picker, settings tabs, community browse / submit modals still work end-to-end
- [ ] After merge: cut `1.0.6` and confirm release workflow produces signed artifacts without the legacy `.zip`