### PR TITLE
fix(engine): correct cursor placement for multi-line snippets and post-variable `$|`

### DIFF
--- a/src/adapters/obsidian-editor.test.ts
+++ b/src/adapters/obsidian-editor.test.ts
@@ -140,18 +140,35 @@ describe("adapters/obsidian-editor: makeContext", () => {
 });
 
 describe("adapters/obsidian-editor: applyEditPlan", () => {
-    it("replaces range and sets new cursor position", () => {
+    it("replaces range and sets new cursor position on the same line", () => {
         const ed = new MockEditor("fn ");
         ed.setCursor({ line: 0, ch: 3 }); // after space
         const plan = {
             fromCh: 0,
             toCh: 2,
             insert: "function () {}",
-            newCursorCh: "function ".length,
+            newCursor: { lineDelta: 0, ch: "function ".length },
         };
         applyEditPlan(ed as any, plan);
         expect(ed.getLine(0)).toBe("function () {} ");
         expect(ed.getCursor()).toEqual({ line: 0, ch: "function ".length });
+    });
+
+    // Regression: F-001 — multi-line insert must move the cursor to the inserted
+    // line, not stay on the original trigger line.
+    it("places cursor on a later line for multi-line inserts", () => {
+        const ed = new MockEditor("cb ");
+        ed.setCursor({ line: 0, ch: 3 });
+        const plan = {
+            fromCh: 0,
+            toCh: 2,
+            insert: "> [!note] \n> ",
+            newCursor: { lineDelta: 1, ch: "> ".length },
+        };
+        applyEditPlan(ed as any, plan);
+        expect(ed.getLine(0)).toBe("> [!note] ");
+        expect(ed.getLine(1)).toBe(">  ");
+        expect(ed.getCursor()).toEqual({ line: 1, ch: "> ".length });
     });
 });
 

--- a/src/adapters/obsidian-editor.ts
+++ b/src/adapters/obsidian-editor.ts
@@ -41,8 +41,11 @@ export function applyEditPlan(editor: Editor, plan: EditPlan) {
     const from: EditorPosition = { line: cur.line, ch: plan.fromCh };
     const to: EditorPosition = { line: cur.line, ch: plan.toCh };
     editor.replaceRange(plan.insert, from, to);
-    if (plan.newCursorCh !== undefined) {
-        editor.setCursor({ line: cur.line, ch: plan.newCursorCh });
+    if (plan.newCursor !== undefined) {
+        editor.setCursor({
+            line: cur.line + plan.newCursor.lineDelta,
+            ch: plan.newCursor.ch,
+        });
     }
 }
 

--- a/src/engine/edit.test.ts
+++ b/src/engine/edit.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from "vitest";
 import { buildEdit } from "./edit";
 
 describe("buildEdit", () => {
-    it("builds edit and computes new cursor position", () => {
+    it("builds edit and computes new cursor position on the same line", () => {
         const input = { textBefore: "fn", textAfter: "", lastTyped: " ", sepCh: 2 };
         const match = { trigger: "fn", fromCh: 0, toCh: 2 };
         const applied = { text: "function () {}", cursorDelta: "function ".length };
@@ -10,7 +10,7 @@ describe("buildEdit", () => {
         expect(plan.insert).toBe("function () {}");
         expect(plan.fromCh).toBe(0);
         expect(plan.toCh).toBe(2);
-        expect(plan.newCursorCh).toBe("function ".length);
+        expect(plan.newCursor).toEqual({ lineDelta: 0, ch: "function ".length });
     });
 
     it("cursor goes to end if no cursorDelta", () => {
@@ -18,6 +18,37 @@ describe("buildEdit", () => {
         const match = { trigger: "brb", fromCh: 0, toCh: 3 };
         const applied = { text: "be right back" };
         const plan = buildEdit(input as any, match as any, applied as any);
-        expect(plan.newCursorCh).toBe("be right back".length);
+        expect(plan.newCursor).toEqual({ lineDelta: 0, ch: "be right back".length });
+    });
+
+    // Regression: F-001 — multi-line replacements should advance lineDelta and
+    // resolve `ch` against the resulting line, not stay on the trigger line.
+    it("multi-line insert with cursor on a later line", () => {
+        const input = { textBefore: "cb", textAfter: "", lastTyped: " ", sepCh: 2 };
+        const match = { trigger: "cb", fromCh: 0, toCh: 2 };
+        // "> [!note] \n> $|"  →  after $| strip in placeholders, the AppliedReplacement
+        // would be: text = "> [!note] \n> ", cursorDelta = 12 (the position of `$|` in the
+        // pre-strip string; equal to length of "> [!note] \n> " here).
+        const applied = { text: "> [!note] \n> ", cursorDelta: "> [!note] \n> ".length };
+        const plan = buildEdit(input as any, match as any, applied as any);
+        expect(plan.newCursor).toEqual({ lineDelta: 1, ch: "> ".length });
+    });
+
+    it("multi-line insert with cursor on the first line still uses lineDelta=0", () => {
+        const input = { textBefore: "cb", textAfter: "", lastTyped: " ", sepCh: 5 };
+        const match = { trigger: "cb", fromCh: 3, toCh: 5 };
+        // Cursor target is at offset 2 ("> $|[!note] \n>"). Even though the
+        // insert contains a newline, the marker is before any newline.
+        const applied = { text: "> [!note] \n> ", cursorDelta: 2 };
+        const plan = buildEdit(input as any, match as any, applied as any);
+        expect(plan.newCursor).toEqual({ lineDelta: 0, ch: 3 /* fromCh */ + 2 });
+    });
+
+    it("multi-line insert with no explicit cursorDelta lands at end of last line", () => {
+        const input = { textBefore: "cb", textAfter: "", lastTyped: " ", sepCh: 2 };
+        const match = { trigger: "cb", fromCh: 0, toCh: 2 };
+        const applied = { text: "line1\nline2" };
+        const plan = buildEdit(input as any, match as any, applied as any);
+        expect(plan.newCursor).toEqual({ lineDelta: 1, ch: "line2".length });
     });
 });

--- a/src/engine/edit.ts
+++ b/src/engine/edit.ts
@@ -9,6 +9,29 @@ export function buildEdit(
     const insert = applied.text;
     const fromCh = m.fromCh;
     const toCh = m.toCh;
-    const newCursorCh = applied.cursorDelta !== undefined ? fromCh + applied.cursorDelta : fromCh + insert.length;
-    return { fromCh, toCh, insert, newCursorCh };
+    const offset = applied.cursorDelta !== undefined ? applied.cursorDelta : insert.length;
+    return { fromCh, toCh, insert, newCursor: offsetToLineCol(insert, offset, fromCh) };
+}
+
+/** Convert a character offset inside `insert` to a (lineDelta, ch) position
+ *  relative to the insert's starting line and column. Walks `insert` once,
+ *  counts newlines, and returns the column on the resulting line. */
+function offsetToLineCol(
+    insert: string,
+    offset: number,
+    fromCh: number
+): { lineDelta: number; ch: number } {
+    let lineDelta = 0;
+    let lastNewline = -1;
+    const end = Math.min(offset, insert.length);
+    for (let i = 0; i < end; i++) {
+        if (insert.charCodeAt(i) === 0x0a /* '\n' */) {
+            lineDelta++;
+            lastNewline = i;
+        }
+    }
+    if (lineDelta === 0) {
+        return { lineDelta: 0, ch: fromCh + offset };
+    }
+    return { lineDelta, ch: offset - lastNewline - 1 };
 }

--- a/src/engine/expand.test.ts
+++ b/src/engine/expand.test.ts
@@ -25,7 +25,7 @@ describe("expand", () => {
         expect(plan!.insert).toBe("function () {}");
         expect(plan!.fromCh).toBe(0);
         expect(plan!.toCh).toBe(2);
-        expect(plan!.newCursorCh).toBe("function ".length);
+        expect(plan!.newCursor).toEqual({ lineDelta: 0, ch: "function ".length });
     });
 
     it("returns null for unknown trigger", async () => {

--- a/src/engine/placeholders.test.ts
+++ b/src/engine/placeholders.test.ts
@@ -36,4 +36,53 @@ describe("applyPlaceholders", () => {
         const r2 = await applyPlaceholders("X $clipboard Y", ctx2 as any);
         expect(r2.text).toBe("X  Y");
     });
+
+    // Regression: F-002 — `$|` was previously located against the raw replacement,
+    // before variable substitution. Any length change in a variable to the left
+    // of `$|` would desync the cursor. The cursor must point to the marker's
+    // position in the FINAL substituted text.
+    it("locates $| after substituting $date (cursor lands at end of expanded date)", async () => {
+        const now = new Date("2026-05-14T10:11:12");
+        const ctx = { isInCode: false, isInMath: false, isInFrontmatter: false, now };
+        const r = await applyPlaceholders("$date $|", ctx as any);
+        expect(r.text).toBe("2026-05-14 ");
+        expect(r.cursorDelta).toBe("2026-05-14 ".length); // 11 — after the substituted date + space
+    });
+
+    it("locates $| after substituting $time", async () => {
+        const now = new Date("2026-05-14T07:08:00");
+        const ctx = { isInCode: false, isInMath: false, isInFrontmatter: false, now };
+        const r = await applyPlaceholders("[$time] $|note", ctx as any);
+        expect(r.text).toBe("[07:08] note");
+        // cursor lands before "note" — i.e. at index 8 of the substituted text
+        expect(r.cursorDelta).toBe("[07:08] ".length);
+    });
+
+    it("locates $| after substituting $filename (incl. empty filename)", async () => {
+        const ctx = {
+            isInCode: false, isInMath: false, isInFrontmatter: false,
+            now: new Date(), filename: "",
+        };
+        const r = await applyPlaceholders("file=$filename $|done", ctx as any);
+        expect(r.text).toBe("file= done");
+        expect(r.cursorDelta).toBe("file= ".length);
+    });
+
+    it("locates $| after substituting $clipboard", async () => {
+        const ctx = {
+            isInCode: false, isInMath: false, isInFrontmatter: false,
+            now: new Date(),
+            readClipboard: async () => "hello",
+        };
+        const r = await applyPlaceholders("[$clipboard] $|", ctx as any);
+        expect(r.text).toBe("[hello] ");
+        expect(r.cursorDelta).toBe("[hello] ".length);
+    });
+
+    it("$| inside a multi-line replacement is resolved against the final text", async () => {
+        const ctx = { isInCode: false, isInMath: false, isInFrontmatter: false, now: new Date() };
+        const r = await applyPlaceholders("> [!note] \n> $|", ctx as any);
+        expect(r.text).toBe("> [!note] \n> ");
+        expect(r.cursorDelta).toBe("> [!note] \n> ".length); // the offset of `$|` in the pre-strip string
+    });
 });

--- a/src/engine/placeholders.ts
+++ b/src/engine/placeholders.ts
@@ -16,16 +16,13 @@ export async function applyPlaceholders(
     ctx: ExpandContext
 ): Promise<AppliedReplacement> {
     let text = replacement;
-    let cursorDelta: number | undefined;
 
-    // $|
-    const markerIndex = text.indexOf(CURSOR);
-    if (markerIndex >= 0) {
-        text = text.slice(0, markerIndex) + text.slice(markerIndex + CURSOR.length);
-        cursorDelta = markerIndex;
-    }
-
-    // simple variables
+    // Substitute variables FIRST so the `$|` cursor marker is located against
+    // the final string. If we resolved `$|` first, any length change in
+    // `$date` / `$time` / `$filename` / `$clipboard` to the left of `$|`
+    // would silently desync the caret (e.g. `"$date $|"` would place the
+    // cursor at index 6 of the *raw* string rather than at the end of the
+    // expanded date).
     text = text.replace(/\$date\b/g, () => formatDate(ctx.now));
     text = text.replace(/\$time\b/g, () => formatTime(ctx.now));
     text = text.replace(/\$filename\b/g, () => ctx.filename ?? "");
@@ -35,6 +32,17 @@ export async function applyPlaceholders(
         text = text.replace(/\$clipboard\b/g, () => clip ?? "");
     } else {
         text = text.replace(/\$clipboard\b/g, "");
+    }
+
+    // Locate `$|` in the substituted text (first occurrence wins, matching
+    // pre-existing behaviour). If a substituted variable happens to contain a
+    // literal `$|` (unlikely outside contrived clipboard payloads), the marker
+    // there will be honoured.
+    let cursorDelta: number | undefined;
+    const markerIndex = text.indexOf(CURSOR);
+    if (markerIndex >= 0) {
+        text = text.slice(0, markerIndex) + text.slice(markerIndex + CURSOR.length);
+        cursorDelta = markerIndex;
     }
 
     return { text, cursorDelta };

--- a/src/engine/types.ts
+++ b/src/engine/types.ts
@@ -35,6 +35,10 @@ export type EditPlan = {
     fromCh: number;
     toCh: number;
     insert: string;
-    /** Absolute cursor position in ch on the same line (after replacement) */
-    newCursorCh?: number;
+    /** Cursor position after replacement, expressed relative to the original
+     *  `(cur.line, fromCh)` position. `lineDelta` counts newlines crossed
+     *  inside `insert`; `ch` is the absolute column on the final line
+     *  (when `lineDelta` > 0, `ch` is the column from the start of that line;
+     *  when `lineDelta` === 0, `ch` is `fromCh + offset`). */
+    newCursor?: { lineDelta: number; ch: number };
 };


### PR DESCRIPTION
## Summary

Two P0 correctness bugs in the snippet expansion engine, both surfaced by the 2026-05-14 code-reviewer agent run:

- **F-001** — multi-line replacements placed the cursor on the wrong line. Any callout/list snippet that uses `$|` after a `\n` (e.g. `> [!note] $|\n> `) landed the caret past end-of-line of the first inserted line.
- **F-002** — `$|` was located against the raw replacement, before variable substitution. Any length change in `$date` / `$time` / `$filename` / `$clipboard` to the left of `$|` silently desynced the caret (e.g. `"$date $|"` placed the cursor at index 6 of the raw string rather than at the end of the expanded date).

Both fixes are contained in the engine + adapter:

- `EditPlan.newCursorCh` (single `ch`) replaced with `newCursor: { lineDelta, ch }`. `buildEdit` counts newlines crossed before the cursor offset and reports the column relative to the final inserted line. `applyEditPlan` applies `cur.line + lineDelta`.
- `applyPlaceholders` substitutes variables FIRST, then locates `$|` in the final string. First-occurrence semantics preserved.

No behavior change for the dominant single-line-without-variables case (existing tests still green).

## Test plan

- [x] `npm run lint` clean
- [x] `npx tsc --noEmit` clean
- [x] `npm test` → 251/251 (was 242; +9 regression tests)
  - Multi-line cursor placement (`edit.test.ts` × 3, `obsidian-editor.test.ts` × 1)
  - Variable-then-`$|` order (`placeholders.test.ts` × 5)
  - Existing `expand.test.ts` updated for new `EditPlan` shape
- [x] `npm run build` → `main.js` 176.1kb
- [ ] CI green on PR
- [ ] After merge: smoke-test multi-line callout snippet in local vault to confirm the regression is gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)