### PR TITLE
feat(ui): 1.1.0 tab strip — new IA, WAI-ARIA, keyboard nav (PR 4c)

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -16,7 +16,9 @@ export interface SnipSidianSettings {
     snippets: Record<string, string>;
     ui?: {
         groupOpen?: Record<string, boolean>;
-        activeTab?: "basic" | "snippets" | "community" | "feedback";
+        /** Stored as a string for forward-compatibility — runtime narrowing
+         *  + migration of pre-1.1.0 values happens in `UIStateManager.loadActiveTab`. */
+        activeTab?: string;
     };
     communityPackages?: {
         cache?: {

--- a/src/ui/components/SettingsTab.ts
+++ b/src/ui/components/SettingsTab.ts
@@ -1,10 +1,22 @@
-import { App, PluginSettingTab, Setting } from "obsidian";
+import { App, PluginSettingTab } from "obsidian";
 import type SnipSidianPlugin from "../../main";
 import { BasicTab } from "./BasicTab";
 import { SnippetsTab } from "./SnippetsTab";
 import { FeedbackTab } from "./FeedbackTab";
 import { CommunityTab } from "./CommunityTab";
-import { UIStateManager } from "../utils/ui-state";
+import { UIStateManager, type TabId } from "../utils/ui-state";
+
+/** Tab strip metadata. Order = visual order. Position 1 (`snippets`) is
+ *  the landing tab — that's where day-to-day work happens per the 1.1.0
+ *  redesign (designer Q1 answer). Internal component names below stay
+ *  legacy (`basicTab`/`communityTab`/`feedbackTab`) — the user-facing
+ *  label change doesn't require renaming the files. */
+const TABS: ReadonlyArray<{ id: TabId; label: string }> = [
+    { id: "snippets", label: "Snippets" },
+    { id: "packages", label: "Packages" },
+    { id: "general", label: "General" },
+    { id: "about", label: "About" },
+];
 
 export class SnipSidianSettingTab extends PluginSettingTab {
     plugin: SnipSidianPlugin;
@@ -32,72 +44,120 @@ export class SnipSidianSettingTab extends PluginSettingTab {
             containerEl.addClass("snipsidian-settings");
         }
 
-        // Header
-        const headerDiv = containerEl.createDiv({ cls: "snipsy-header" });
-        new Setting(headerDiv).setHeading().setName("Snipsy settings");
+        // Tab strip. WAI-ARIA tabs pattern per accessibility audit A-002
+        // (B-083): the container is `role="tablist"`, each button is
+        // `role="tab"` with `aria-selected` + `aria-controls` pointing
+        // at the panel, the panel is `role="tabpanel"` labelled by its
+        // tab. Arrow keys + Home/End move focus and activation; the
+        // active tab is the only one in the tab order (roving tabindex).
+        const tabList = containerEl.createDiv({ cls: "snipsy-tabs" });
+        tabList.setAttr("role", "tablist");
+        tabList.setAttr("aria-label", "Snipsy settings sections");
 
-        // Tab navigation
-        const tabs = [
-            { id: "basic" as const, label: "General" },
-            { id: "snippets" as const, label: "Snippets Manager" },
-            { id: "community" as const, label: "Community Packages" },
-            { id: "feedback" as const, label: "Feedback" },
-        ];
+        const tabPanel = containerEl.createDiv({ cls: "snipsy-tab-content" });
+        tabPanel.setAttr("role", "tabpanel");
 
-        const tabContainer = containerEl.createDiv({ cls: "snipsy-tabs" });
-        const tabButtons = tabContainer.createDiv({ cls: "tab-buttons" });
-        const tabContent = tabContainer.createDiv({ cls: "tab-content" });
+        // Read + migrate any pre-1.1.0 stored value, then commit so the
+        // saved settings reflect the new IA on the next persist.
+        const initialActive = this.uiState.loadActiveTab();
+        this.uiState.setActiveTab(initialActive);
 
-        // Load active tab from settings
-        const activeTab = this.uiState.loadActiveTab();
-        this.uiState.setActiveTab(activeTab);
+        const tabButtons: HTMLButtonElement[] = [];
 
-        // Create tab buttons
-        for (const t of tabs) {
-            const btn = tabButtons.createEl("button", {
-                text: t.label,
-                cls: `tab-button ${this.uiState.getActiveTab() === t.id ? "active" : ""}`,
+        const activateTab = (id: TabId, focusButton: boolean) => {
+            this.uiState.setActiveTab(id);
+
+            for (let i = 0; i < TABS.length; i++) {
+                const meta = TABS[i];
+                const btn = tabButtons[i];
+                if (!meta || !btn) continue;
+                const isActive = meta.id === id;
+                btn.toggleClass("is-active", isActive);
+                btn.setAttr("aria-selected", isActive ? "true" : "false");
+                btn.setAttr("tabindex", isActive ? "0" : "-1");
+            }
+
+            tabPanel.setAttr("id", `snipsy-panel-${id}`);
+            tabPanel.setAttr("aria-labelledby", `snipsy-tab-${id}`);
+            this.renderTabContent(tabPanel, id);
+
+            if (focusButton) {
+                const idx = TABS.findIndex((t) => t.id === id);
+                tabButtons[idx]?.focus();
+            }
+        };
+
+        for (let i = 0; i < TABS.length; i++) {
+            const meta = TABS[i];
+            if (!meta) continue;
+            const isActive = meta.id === initialActive;
+
+            const btn = tabList.createEl("button", {
+                text: meta.label,
+                cls: `snipsy-tab${isActive ? " is-active" : ""}`,
+            });
+            btn.setAttr("type", "button");
+            btn.setAttr("role", "tab");
+            btn.setAttr("id", `snipsy-tab-${meta.id}`);
+            btn.setAttr("aria-controls", `snipsy-panel-${meta.id}`);
+            btn.setAttr("aria-selected", isActive ? "true" : "false");
+            // Roving tabindex: only the active tab is in the page tab
+            // order. Arrow keys move both focus and activation.
+            btn.setAttr("tabindex", isActive ? "0" : "-1");
+
+            // Mouse click — don't refocus, the user's pointer is already
+            // there and forcing focus back fights screen-reader users
+            // who may have arrowed elsewhere.
+            btn.onclick = () => activateTab(meta.id, false);
+
+            btn.addEventListener("keydown", (e) => {
+                let nextIdx: number | null = null;
+                switch (e.key) {
+                    case "ArrowRight":
+                        nextIdx = (i + 1) % TABS.length;
+                        break;
+                    case "ArrowLeft":
+                        nextIdx = (i - 1 + TABS.length) % TABS.length;
+                        break;
+                    case "Home":
+                        nextIdx = 0;
+                        break;
+                    case "End":
+                        nextIdx = TABS.length - 1;
+                        break;
+                }
+                if (nextIdx !== null) {
+                    e.preventDefault();
+                    const target = TABS[nextIdx];
+                    if (target) activateTab(target.id, true);
+                }
             });
 
-            btn.onclick = () => {
-                this.uiState.setActiveTab(t.id);
-                this.renderTabContent(tabContent);
-                this.updateTabButtons(tabButtons, tabs);
-            };
+            tabButtons.push(btn);
         }
 
-        // Render initial content
-        this.renderTabContent(tabContent);
+        // Initial panel render.
+        tabPanel.setAttr("id", `snipsy-panel-${initialActive}`);
+        tabPanel.setAttr("aria-labelledby", `snipsy-tab-${initialActive}`);
+        this.renderTabContent(tabPanel, initialActive);
     }
 
-    private renderTabContent(container: HTMLElement) {
+    private renderTabContent(container: HTMLElement, id: TabId) {
         container.empty();
 
-        switch (this.uiState.getActiveTab()) {
-            case "basic":
-                this.basicTab.render(container);
-                break;
+        switch (id) {
             case "snippets":
                 this.snippetsTab.render(container);
                 break;
-            case "community":
+            case "packages":
                 void this.communityTab.render(container);
                 break;
-            case "feedback":
+            case "general":
+                this.basicTab.render(container);
+                break;
+            case "about":
                 this.feedbackTab.render(container);
                 break;
         }
-    }
-
-    private updateTabButtons(container: HTMLElement, tabs: Array<{ id: string; label: string }>) {
-        const buttons = container.querySelectorAll(".tab-button");
-        buttons.forEach((btn, index) => {
-            const tab = tabs[index];
-            if (tab && this.uiState.getActiveTab() === tab.id) {
-                btn.classList.add("active");
-            } else {
-                btn.classList.remove("active");
-            }
-        });
     }
 }

--- a/src/ui/utils/ui-state.ts
+++ b/src/ui/utils/ui-state.ts
@@ -1,13 +1,39 @@
 import type { SnipSidianSettings } from "../../types";
 
-export type TabId = "basic" | "snippets" | "community" | "feedback";
+/** Tab identifiers used inside the new 1.1.0 IA. Storage may still
+ *  contain pre-1.1.0 IDs (`basic` / `community` / `feedback`) — those
+ *  are migrated transparently in `loadActiveTab()`. */
+export type TabId = "snippets" | "packages" | "general" | "about";
+
+/** Migration map from pre-1.1.0 stored IDs to the new IA labels.
+ *  - old `basic` (General tab) → new `general` (position 3)
+ *  - old `community` (Community Packages tab) → new `packages` (position 2)
+ *  - old `feedback` (Feedback tab) → new `about` (position 4)
+ *  - old `snippets` stays as `snippets` (now position 1, landing)
+ *  See ADR-0006 + designer Q1 answer. */
+const LEGACY_TAB_ID_MAP: Record<string, TabId> = {
+    basic: "general",
+    snippets: "snippets",
+    community: "packages",
+    feedback: "about",
+};
+
+const VALID_TAB_IDS: ReadonlySet<TabId> = new Set<TabId>([
+    "snippets",
+    "packages",
+    "general",
+    "about",
+]);
 
 /** Persist callback. Called whenever UI state that lives in
  *  `settings.ui` is mutated. May be sync (returns void) or async. */
 type Persist = () => void | Promise<void>;
 
 export class UIStateManager {
-    private activeTab: TabId = "basic";
+    /** Default landing tab. "Snippets" because that's where day-to-day
+     *  work happens — most users open Settings to manage their library
+     *  (designer Q1 answer). */
+    private activeTab: TabId = "snippets";
     private groupOpen = new Map<string, boolean>();
     private searchQuery = "";
     private selectionMode = false;
@@ -51,9 +77,23 @@ export class UIStateManager {
 
     loadActiveTab(): TabId {
         this.ensureUiState();
-        const v = this.settings.ui!.activeTab;
-        if (v === "basic" || v === "snippets" || v === "community" || v === "feedback") return v;
-        return "basic";
+        const raw = this.settings.ui!.activeTab as string | undefined;
+
+        // New-ID happy path.
+        if (raw && VALID_TAB_IDS.has(raw as TabId)) return raw as TabId;
+
+        // Pre-1.1.0 stored IDs — migrate to the new IA. We also
+        // overwrite the stored value in-memory so future reads land in
+        // the happy path. (The actual disk write happens on the next
+        // `saveActiveTab` call.)
+        if (raw && LEGACY_TAB_ID_MAP[raw]) {
+            const migrated = LEGACY_TAB_ID_MAP[raw];
+            this.settings.ui!.activeTab = migrated;
+            return migrated;
+        }
+
+        // Corrupted / first-launch — default to landing.
+        return "snippets";
     }
 
     saveActiveTab(tab: TabId) {


### PR DESCRIPTION
## Summary

PR 4c of the 1.1.0 redesign series. Targets \`epic/1.1.0-redesign\`. Rewrites the settings tab strip with the new information architecture, WAI-ARIA roles, and keyboard navigation. **Content is untouched** — each tab still renders the same component as before, just with a new label / position / id.

### Tab reshuffle (Q1=b)

| Old position | Old label | Old id | → | New position | New label | New id |
|---|---|---|---|---|---|---|
| 1 | General | \`basic\` | → | 3 | General | \`general\` |
| 2 | Snippets Manager | \`snippets\` | → | **1 (landing)** | **Snippets** | \`snippets\` |
| 3 | Community Packages | \`community\` | → | 2 | Packages | \`packages\` |
| 4 | Feedback | \`feedback\` | → | 4 | About | \`about\` |

"Snippets" lands users on the most-used surface. Per designer Q1.

### Persistence migration

\`UIStateManager.loadActiveTab()\` now handles pre-1.1.0 stored IDs transparently:

- \`basic\` → \`general\`
- \`community\` → \`packages\`
- \`feedback\` → \`about\`
- \`snippets\` → \`snippets\`
- corrupted / unknown → \`snippets\` (landing default)

Migrated value is committed back to settings on the next save. No user-visible disruption.

### Accessibility (B-083 closed)

WAI-ARIA tabs pattern fully implemented:

- \`<div class="snipsy-tabs" role="tablist" aria-label="Snipsy settings sections">\`
- Each tab: \`<button role="tab" aria-selected aria-controls id tabindex>\`
- Panel: \`<div role="tabpanel" aria-labelledby id>\`
- Roving tabindex — only the active tab is in the document tab order
- ArrowLeft/Right move focus + selection (wrap at ends), Home/End jump to first/last
- Tab key leaves the tablist entirely (WAI-ARIA auto-activate pattern)

### Also

Dropped the redundant \`new Setting(headerDiv).setHeading().setName("Snipsy settings")\` header — Obsidian already shows the plugin name in the settings sidebar, and the new design doesn't include a duplicate inside the panel.

## Backlog impact

- ✅ **B-098** — tab strip + IA reshuffle + persistence migration
- ✅ **B-050** — short sentence-case tab labels
- ✅ **B-083** — WAI-ARIA \`role="tablist"\` + arrow-key switching

## What did NOT change

- **Content of each tab** — still uses \`snippetsTab\` / \`communityTab\` / \`basicTab\` / \`feedbackTab\` component instances. The headings, toolbars, and CTAs *inside* each tab will be rewritten in PRs 4d / 4e / 4f. Expect intermediate visual states until those land.
- **Component file names** (\`BasicTab.ts\` / \`FeedbackTab.ts\` etc.) — cosmetic rename deferred. The internal property names on \`SnipSidianSettingTab\` (\`basicTab\` / \`feedbackTab\`) are now legacy but harmless.

## Numbers

- 3 files changed, +161/−59 lines net
- 235/235 tests passing
- Lint / tsc clean
- main.js 179.8kb

## Test plan

- [x] \`npm run lint\` clean
- [x] \`npx tsc --noEmit\` clean
- [x] \`npm test\` → 235/235
- [x] \`npm run build\` succeeds
- [x] Built into local vault
- [ ] CI green on PR
- [ ] **Smoke test in Obsidian (please verify):**
  - Open Settings → Snipsy
  - Tabs should read \`Snippets / Packages / General / About\` in that order
  - Active tab should be **Snippets** (landing)
  - If you had a non-\`snippets\` tab active before this PR, the migration should land you on the equivalent new tab (\`Community Packages\` → **Packages**, \`General\` → **General**, \`Feedback\` → **About**)
  - **Keyboard**: focus a tab via Tab key from outside the strip, then ArrowLeft/Right cycle between tabs (with wrap), Home/End jump to first/last. The Tab key from a tab moves focus out of the strip into the tab's content.
  - **Screen reader (NVDA/VoiceOver):** announced as "tab list, Snippets, tab, selected, 1 of 4" when focused. Arrow-key activation announces the newly-selected tab.
  - Visual: tab strip is the new bottom-border-indicator style from PR 4b CSS, not the old colored-button strip.

Targets \`epic/1.1.0-redesign\` — final tag / release happens after the whole epic merges to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)