### PR TITLE
feat(ui): 1.1.0 SnippetsTab rewrite — toolbar + single-edit-mode (PR 4d)

### DIFF
--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -75,6 +75,22 @@
   color: var(--snipsy-on-accent);
 }
 
+/* Utility — used by tab JS to hide/show without setting inline
+   styles (Obsidian's `no-static-styles-assignment` lint rule forbids
+   `el.style.display = "none"`). Keep this near the top so anything can
+   use it. */
+.snipsidian-settings .is-hidden { display: none !important; }
+
+/* ---- Snippets-tab heading ---- */
+/* Real <h3> per accessibility audit (B-091) — `Setting().setHeading()`
+   renders a styled div, which is invisible to screen readers as a
+   structural heading. */
+.snipsidian-settings .snipsy-tab-heading {
+  font-size: 16px;
+  font-weight: 600;
+  margin: 4px 0 12px;
+}
+
 /* ---- Search bar ---- */
 .snipsidian-settings .snipsy-search {
   position: relative;
@@ -82,6 +98,7 @@
 }
 .snipsidian-settings .snipsy-search input {
   padding-left: 30px;
+  width: 100%;
 }
 .snipsidian-settings .snipsy-search .snipsy-search-icon {
   position: absolute;
@@ -90,6 +107,23 @@
   transform: translateY(-50%);
   color: var(--snipsy-text-faint);
   pointer-events: none;
+}
+
+/* ---- Snippet toolbar (search + actions row above the list) ---- */
+.snipsidian-settings .snipsy-snippet-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
+/* Filter count badge (B-099) — only rendered when a search query is
+   active. Tells the user how many results their query returned without
+   forcing them to scroll the list. */
+.snipsidian-settings .snipsy-filter-count {
+  font-size: 12px;
+  color: var(--snipsy-text-faint);
+  white-space: nowrap;
 }
 
 /* ---- Snippet list ---- */

--- a/src/ui/components/SnippetsTab.ts
+++ b/src/ui/components/SnippetsTab.ts
@@ -1,4 +1,4 @@
-import { App, Notice, Setting } from "obsidian";
+import { App, Notice, setIcon } from "obsidian";
 import type SnipSidianPlugin from "../../main";
 import { normalizeTrigger, isBadTrigger, splitKey, joinKey, slugifyGroup } from "../../services/utils";
 import { GroupManager } from "../utils/group-utils";
@@ -6,156 +6,241 @@ import { UIStateManager } from "../utils/ui-state";
 import { AddSnippetModal, ConfirmModal, GroupPickerModal, TextPromptModal } from "./Modals";
 import { hasTriggerCollision } from "../../store/snippets";
 
-interface EditData {
-    trigger: string;
-    triggerName: string;
-    replacement: string;
-    triggerInput: HTMLInputElement;
-    replacementInput: HTMLTextAreaElement;
-    saveBtn: HTMLButtonElement;
-    cancelBtn: HTMLButtonElement;
-    editBtn: HTMLButtonElement;
-}
-
-interface SettingWithEditData extends Setting {
-    editData?: EditData;
-}
-
 export class SnippetsTab {
     private groupManager: GroupManager;
     private uiState: UIStateManager;
+    /** Cached root for re-renders triggered outside `render()` (e.g. after
+     *  a modal resolves). Re-renders always target the list container,
+     *  never the whole tab — the toolbar/heading stay mounted. */
+    private listEl: HTMLElement | null = null;
+    /** Search input is read by the list renderer for the result-count
+     *  badge (B-099). Re-renders never recreate it, so focus and cursor
+     *  position survive typing. */
+    private searchInput: HTMLInputElement | null = null;
+    /** Result-count badge — shown only when search is non-empty. */
+    private countBadge: HTMLSpanElement | null = null;
+    /** Bulk bar wrapper — toggled by selection state, never re-mounted. */
+    private bulkBar: HTMLElement | null = null;
 
     constructor(
         private app: App,
-        private plugin: SnipSidianPlugin
+        private plugin: SnipSidianPlugin,
     ) {
         this.groupManager = new GroupManager();
         this.uiState = new UIStateManager(this.plugin.settings, () => this.plugin.saveSettings());
     }
 
     render(root: HTMLElement) {
-        // Main Snippet Manager section
-        const managerSection = root.createDiv({ cls: "snipsy-section snipsy-snippet-manager" });
-        new Setting(managerSection)
-            .setHeading()
-            .setName("Snippet manager")
-            .setDesc("Manage your text expansion snippets with search, bulk operations, and organization tools");
+        root.empty();
 
-        // Search subsection
-        const searchSubsection = managerSection.createDiv({ cls: "snipsy-subsection" });
-        new Setting(searchSubsection)
-            .setHeading()
-            .setName("Search & filter");
-        
-        new Setting(searchSubsection)
-            .setName("Search snippets")
-            .setDesc("Filter snippets by trigger or replacement text")
-            .addText((text) => {
-                text
-                    .setPlaceholder("Search...")
-                    .setValue(this.uiState.getSearchQuery())
-                    .onChange((value) => {
-                        this.uiState.setSearchQuery(value);
-                        this.renderSnippetList(root);
-                    });
-            });
+        // Real heading element (B-091): screen readers need <h3>, not
+        // a styled-div `.setting-item-heading`.
+        root.createEl("h3", { text: "Snippets", cls: "snipsy-tab-heading" });
 
-        // Controls subsection
-        const controlsSubsection = managerSection.createDiv({ cls: "snipsy-subsection" });
-        new Setting(controlsSubsection)
-            .setHeading()
-            .setName("Management tools");
-        
-        // Selection mode and group controls in one row
-        const controlsRow = controlsSubsection.createDiv({ cls: "snipsy-controls-row" });
-        
-        // Selection mode
-        const selectionModeDiv = controlsRow.createDiv({ cls: "snipsy-control-item" });
-        new Setting(selectionModeDiv)
-            .setName("Selection mode")
-            .setDesc("Enable multi-select for bulk operations")
-            .addToggle((toggle) => {
-                toggle
-                    .setValue(this.uiState.getSelectionMode())
-                    .onChange((value) => {
-                        this.uiState.setSelectionMode(value);
-                        this.uiState.setSelected(new Set());
-                        this.renderSnippetList(root);
-                    });
-            });
+        this.renderToolbar(root);
+        this.renderBulkBar(root);
 
-        // Group controls
-        const groupControlsDiv = controlsRow.createDiv({ cls: "snipsy-control-item" });
-        new Setting(groupControlsDiv)
-            .setName("Expand all groups")
-            .setDesc("Toggle all groups open/closed")
-            .addToggle((toggle) => {
-                // Check if all groups are open
-                const groups = this.groupManager.allGroupsFrom(this.plugin.settings.snippets);
-                const allOpen = groups.length > 0 && groups.every(group => this.uiState.loadOpenState(group, false));
-                toggle.setValue(allOpen);
-                
-                toggle.onChange((value) => {
-                    groups.forEach((group) => {
-                        this.uiState.setGroupOpen(group, value);
-                    });
-                    this.renderSnippetList(root);
-                });
-            });
-
-        // Add new snippet button in management tools
-        const addSnippetDiv = controlsSubsection.createDiv({ cls: "snipsy-add-snippet" });
-        new Setting(addSnippetDiv)
-            .setName("Add new snippet")
-            .setDesc("Create a new text expansion snippet")
-            .addButton((btn) => {
-                btn.setButtonText("Add new snippet");
-                btn.setCta();
-                btn.onClick(() => {
-                    this.showAddSnippetModal();
-                });
-            });
-
-        // Snippets subsection (created once)
-        const snippetsSubsection = managerSection.createDiv({ cls: "snipsy-subsection" });
-        new Setting(snippetsSubsection)
-            .setHeading()
-            .setName("Your snippets");
-        const listEl = snippetsSubsection.createDiv({ cls: "snippet-list" });
-        
-        // Render snippet list content
-        this.renderSnippetListContent(listEl, root);
+        this.listEl = root.createDiv({ cls: "snippet-list" });
+        this.renderList();
     }
 
-    private renderSnippetList(root: HTMLElement) {
-        // Find existing list container
-        const listEl = root.querySelector(".snippet-list");
-        if (!listEl) return;
+    private renderToolbar(root: HTMLElement) {
+        const toolbar = root.createDiv({ cls: "snipsy-snippet-toolbar" });
 
-        // Clear existing content
-        listEl.empty();
+        // Search input — wrapped in `.snipsy-search` so the icon overlays
+        // correctly (the icon is absolutely positioned inside the wrapper).
+        const searchWrap = toolbar.createDiv({ cls: "snipsy-search" });
+        const iconEl = searchWrap.createSpan({ cls: "snipsy-search-icon" });
+        setIcon(iconEl, "search");
 
-        // Render bulk operations if in selection mode and items are selected
-        if (this.uiState.getSelectionMode() && this.uiState.getSelected().size > 0) {
-            this.renderBulkOperations(listEl as HTMLElement, root);
-        }
+        const input = searchWrap.createEl("input", {
+            type: "text",
+            attr: {
+                placeholder: "Filter triggers or replacements",
+                "aria-label": "Filter snippets",
+            },
+        });
+        input.value = this.uiState.getSearchQuery();
+        input.addEventListener("input", () => {
+            this.uiState.setSearchQuery(input.value);
+            this.renderList();
+        });
+        this.searchInput = input;
 
-        // Render snippet list content
-        this.renderSnippetListContent(listEl as HTMLElement, root);
+        // Result-count badge (B-099). Hidden by default; the list
+        // renderer fills it in when there's a non-empty search query.
+        this.countBadge = toolbar.createSpan({ cls: "snipsy-filter-count is-hidden" });
+
+        const selBtn = toolbar.createEl("button", {
+            cls: "snippet-action",
+            attr: { type: "button" },
+        });
+        this.refreshSelectionButton(selBtn);
+        selBtn.addEventListener("click", () => {
+            const next = !this.uiState.getSelectionMode();
+            this.uiState.setSelectionMode(next);
+            if (!next) this.uiState.setSelected(new Set());
+            this.refreshSelectionButton(selBtn);
+            this.renderList();
+        });
+
+        const expandBtn = toolbar.createEl("button", {
+            cls: "snippet-action",
+            attr: { type: "button" },
+        });
+        this.refreshExpandButton(expandBtn);
+        expandBtn.addEventListener("click", () => {
+            const groups = this.groupManager.allGroupsFrom(this.plugin.settings.snippets);
+            const allOpen =
+                groups.length > 0 &&
+                groups.every((g) => this.uiState.loadOpenState(g, false));
+            const target = !allOpen;
+            for (const g of groups) {
+                this.uiState.setGroupOpen(g, target);
+            }
+            this.refreshExpandButton(expandBtn);
+            this.renderList();
+        });
+
+        // Single primary CTA. Plain `.mod-cta` class wires it to the
+        // accent color via the scoped stylesheet.
+        const addBtn = toolbar.createEl("button", {
+            cls: "snippet-action mod-cta",
+            text: "Add snippet",
+            attr: { type: "button" },
+        });
+        addBtn.addEventListener("click", () => this.showAddSnippetModal());
     }
 
-    private renderSnippetListContent(listEl: HTMLElement, root: HTMLElement) {
+    private refreshSelectionButton(btn: HTMLButtonElement) {
+        btn.textContent = this.uiState.getSelectionMode() ? "Done selecting" : "Select";
+        btn.setAttr("aria-pressed", this.uiState.getSelectionMode() ? "true" : "false");
+    }
 
-        const searchQuery = this.uiState.getSearchQuery().toLowerCase();
-        const entries = Object.entries(this.plugin.settings.snippets)
-            .filter(([key, value]) => 
-                !searchQuery || 
-                key.toLowerCase().includes(searchQuery) || 
-                value.toLowerCase().includes(searchQuery)
+    private refreshExpandButton(btn: HTMLButtonElement) {
+        const groups = this.groupManager.allGroupsFrom(this.plugin.settings.snippets);
+        const allOpen =
+            groups.length > 0 &&
+            groups.every((g) => this.uiState.loadOpenState(g, false));
+        btn.textContent = allOpen ? "Collapse all" : "Expand all";
+    }
+
+    private renderBulkBar(root: HTMLElement) {
+        // Sticky bar lives above the list. Hidden when nothing's selected
+        // so it never wastes vertical space (designer Q3).
+        this.bulkBar = root.createDiv({ cls: "snipsy-bulk-bar is-hidden" });
+    }
+
+    private updateBulkBar() {
+        if (!this.bulkBar) return;
+        const count = this.uiState.getSelected().size;
+        const visible = this.uiState.getSelectionMode() && count > 0;
+        this.bulkBar.toggleClass("is-hidden", !visible);
+        this.bulkBar.empty();
+        if (!visible) return;
+
+        this.bulkBar.createSpan({
+            text: `${count} selected`,
+        });
+
+        const moveBtn = this.bulkBar.createEl("button", {
+            cls: "snippet-action",
+            text: "Move to group",
+            attr: { type: "button" },
+        });
+        moveBtn.addEventListener("click", () => {
+            const groups = this.groupManager.allGroupsFrom(this.plugin.settings.snippets);
+            const modal = new GroupPickerModal(this.app, {
+                title: "Move to group:",
+                groups,
+                allowUngrouped: true,
+            });
+            modal.onSubmit = (targetGroup) => {
+                if (targetGroup === null) return;
+                void this.moveSelectedSnippets(targetGroup);
+            };
+            modal.open();
+        });
+
+        const deleteBtn = this.bulkBar.createEl("button", {
+            cls: "snippet-action is-danger",
+            text: "Delete",
+            attr: { type: "button" },
+        });
+        deleteBtn.addEventListener("click", () => {
+            const n = this.uiState.getSelected().size;
+            const modal = new ConfirmModal(this.app, {
+                title: "Delete snippets",
+                message: `Delete ${n} snippet(s)?`,
+                confirmText: "Delete",
+                onConfirm: async () => {
+                    for (const key of this.uiState.getSelected()) {
+                        delete this.plugin.settings.snippets[key];
+                    }
+                    await this.plugin.saveSettings();
+                    this.uiState.setSelected(new Set());
+                    this.discardEditIfMissing();
+                    this.renderList();
+                    new Notice(`Deleted ${n} snippet(s).`);
+                },
+            });
+            modal.open();
+        });
+
+        const clearBtn = this.bulkBar.createEl("button", {
+            cls: "snippet-action",
+            text: "Clear",
+            attr: { type: "button" },
+        });
+        clearBtn.addEventListener("click", () => {
+            this.uiState.setSelected(new Set());
+            this.updateBulkBar();
+            this.renderList();
+        });
+    }
+
+    private renderList() {
+        if (!this.listEl) return;
+        this.listEl.empty();
+
+        const rawQuery = this.uiState.getSearchQuery();
+        const searchQuery = rawQuery.toLowerCase();
+        const allEntries = Object.entries(this.plugin.settings.snippets);
+        const entries = allEntries
+            .filter(
+                ([key, value]) =>
+                    !searchQuery ||
+                    key.toLowerCase().includes(searchQuery) ||
+                    value.toLowerCase().includes(searchQuery),
             )
             .sort(([a], [b]) => a.localeCompare(b));
 
-        // Group snippets
+        // Result-count badge (B-099). Shown only when there is an active
+        // query — empty state is signaled by the empty-state block below.
+        if (this.countBadge) {
+            const visible = rawQuery.length > 0;
+            this.countBadge.toggleClass("is-hidden", !visible);
+            this.countBadge.textContent = visible
+                ? `${entries.length} of ${allEntries.length}`
+                : "";
+        }
+
+        this.updateBulkBar();
+
+        if (entries.length === 0) {
+            const empty = this.listEl.createDiv({ cls: "snipsy-empty" });
+            if (allEntries.length === 0) {
+                empty.createEl("p", { text: "No snippets yet." });
+                empty.createEl("p", {
+                    text: "Add your first snippet or install a community package.",
+                });
+            } else {
+                empty.createEl("p", { text: "No snippets match your filter." });
+            }
+            return;
+        }
+
+        // Group snippets by folder.
         const groups = new Map<string, Array<[string, string]>>();
         for (const e of entries) {
             const [k] = e;
@@ -164,238 +249,326 @@ export class SnippetsTab {
             groups.get(group)!.push(e);
         }
 
-        // Ensure groupOpen has defaults
         for (const g of groups.keys()) {
             if (!this.uiState.getGroupOpen().has(g)) {
                 this.uiState.setGroupOpen(g, this.uiState.loadOpenState(g, false));
             }
         }
 
-        // Render groups
         for (const [group, items] of groups.entries()) {
             const isOpen = this.uiState.getGroupOpen().get(group) ?? false;
             const title = group === "" ? "Ungrouped" : this.groupManager.displayGroupTitle(group);
-            
-            const groupEl = listEl.createDiv({ cls: "snippet-group" });
-            const header = groupEl.createDiv({ cls: "group-header" });
-            
-            // Group toggle
-            const toggle = header.createEl("button", { 
-                cls: `group-toggle ${isOpen ? "open" : ""}`,
-                text: isOpen ? "▼" : "▶"
+            this.renderGroup(group, title, items, isOpen);
+        }
+    }
+
+    private renderGroup(
+        group: string,
+        title: string,
+        items: Array<[string, string]>,
+        isOpen: boolean,
+    ) {
+        if (!this.listEl) return;
+
+        const groupEl = this.listEl.createDiv({ cls: "snippet-group" });
+        const header = groupEl.createDiv({ cls: "group-header" });
+
+        // Chevron toggle. setIcon renders an SVG; we toggle the
+        // `.open` class to rotate it 90° via CSS (no glyph swap).
+        const toggle = header.createEl("button", {
+            cls: `group-toggle${isOpen ? " open" : ""}`,
+            attr: {
+                type: "button",
+                "aria-expanded": isOpen ? "true" : "false",
+                "aria-label": `${isOpen ? "Collapse" : "Expand"} group ${title}`,
+            },
+        });
+        setIcon(toggle, "chevron-right");
+        toggle.addEventListener("click", () => {
+            this.uiState.setGroupOpen(group, !isOpen);
+            this.renderList();
+        });
+
+        header.createSpan({ text: title, cls: "group-title" });
+        header.createSpan({ text: `${items.length}`, cls: "group-count" });
+
+        const actions = header.createDiv({ cls: "group-actions" });
+
+        if (this.uiState.getSelectionMode()) {
+            const selectAllCb = actions.createEl("input", {
+                type: "checkbox",
+                attr: { "aria-label": `Select all in group ${title}` },
             });
-            toggle.onclick = () => {
-                this.uiState.setGroupOpen(group, !isOpen);
-                this.renderSnippetList(root);
-            };
-
-            // Group title
-            header.createSpan({ text: title, cls: "group-title" });
-
-            // Group actions
-            const actions = header.createDiv({ cls: "group-actions" });
-            
-            // Select all checkbox (in selection mode)
-            if (this.uiState.getSelectionMode()) {
-                const selectAllCb = actions.createEl("input", { type: "checkbox" });
-                selectAllCb.checked = items.every(([key]) => this.uiState.getSelected().has(key));
-                selectAllCb.onchange = () => {
-                    if (selectAllCb.checked) {
-                        items.forEach(([key]) => this.uiState.getSelected().add(key));
-                    } else {
-                        items.forEach(([key]) => this.uiState.getSelected().delete(key));
-                    }
-                    // Re-render to update bulk operations section
-                    this.renderSnippetList(root);
-                };
-                selectAllCb.title = "Select all in group";
-            }
-            
-            // Rename group
-            const renameBtn = actions.createEl("button", { 
-                text: "✏️", 
-                cls: "group-action-btn rename-btn",
-                title: "Rename group"
-            });
-            renameBtn.onclick = () => {
-                const modal = new TextPromptModal(this.app, {
-                    title: "Rename group:",
-                    initial: title,
-                    validate: (v) => {
-                        const trimmed = v.trim();
-                        if (!trimmed) return "Group name cannot be empty";
-                        if (!slugifyGroup(trimmed)) return "Group name must contain at least one letter or number";
-                        return null;
-                    },
-                    onSubmit: (newTitle) => {
-                        void this.renameGroup(root, group, title, items, isOpen, newTitle);
-                    },
-                });
-                modal.open();
-            };
-
-            // Delete group
-            const deleteBtn = actions.createEl("button", { 
-                text: "🗑️", 
-                cls: "group-action-btn delete-btn",
-                title: "Delete group"
-            });
-            deleteBtn.onclick = () => {
-                const modal = new ConfirmModal(this.app, {
-                    title: "Delete group",
-                    message: `Delete group "${title}" with ${items.length} snippet(s)?`,
-                    confirmText: "Delete",
-                    onConfirm: async () => {
-                        for (const [key] of items) {
-                            delete this.plugin.settings.snippets[key];
-                        }
-                        await this.plugin.saveSettings();
-                        this.uiState.getGroupOpen().delete(group);
-                        this.renderSnippetList(root);
-                        new Notice(`Deleted ${items.length} snippet(s) from "${title}".`);
-                    }
-                });
-                modal.open();
-            };
-
-            // Group content
-            if (isOpen) {
-                const content = groupEl.createDiv({ cls: "group-content" });
-                
-                for (const [trigger, replacement] of items) {
-                    const row = new Setting(content);
-                    const { name: triggerName } = splitKey(trigger);
-                    row.setName(triggerName);
-                    row.setDesc(replacement || "");
-                    
-                    
-                    // Selection checkbox (in selection mode)
-                    if (this.uiState.getSelectionMode()) {
-                        const cb = row.controlEl.createEl("input", { type: "checkbox" });
-                        cb.checked = this.uiState.getSelected().has(trigger);
-                        cb.onchange = () => {
-                            if (cb.checked) {
-                                this.uiState.getSelected().add(trigger);
-                            } else {
-                                this.uiState.getSelected().delete(trigger);
-                            }
-                            // Re-render to update bulk operations section
-                            this.renderSnippetList(root);
-                        };
-                        row.controlEl.insertAdjacentElement("afterbegin", cb);
-                    }
-
-                    // Action buttons container
-                    const actionsContainer = row.controlEl.createDiv({ cls: "snippet-actions" });
-                    
-                    // Edit button
-                    const editBtn = actionsContainer.createEl("button", { 
-                        text: "✏️", 
-                        cls: "snippet-action edit-btn",
-                        title: "Edit snippet"
-                    });
-                    
-                    // Delete button
-                    const deleteBtn = actionsContainer.createEl("button", { 
-                        text: "🗑️", 
-                        cls: "snippet-action delete-btn",
-                        title: "Delete snippet"
-                    });
-                    
-                    // Edit mode state
-                    let isEditing = false;
-                    
-                    // Edit button click handler
-                    editBtn.onclick = () => {
-                        if (isEditing) {
-                            // Save changes
-                            const root = activeDocument.querySelector('.snipsidian-settings');
-                            if (root) {
-                                void this.saveSnippetChanges(row, trigger, triggerName, replacement, root as HTMLElement);
-                            }
-                        } else {
-                            // Enter edit mode
-                            this.enterEditMode(row, trigger, triggerName, replacement, editBtn);
-                            isEditing = true;
-                        }
-                    };
-                    
-                    // Delete button click handler
-                    deleteBtn.onclick = () => {
-                        const modal = new ConfirmModal(this.app, {
-                            title: "Delete snippet",
-                            message: `Delete snippet "${triggerName}"?`,
-                            confirmText: "Delete",
-                            onConfirm: async () => {
-                                delete this.plugin.settings.snippets[trigger];
-                                await this.plugin.saveSettings();
-                                this.renderSnippetList(root);
-                            }
-                        });
-                        modal.open();
-                    };
+            selectAllCb.checked = items.every(([key]) => this.uiState.getSelected().has(key));
+            selectAllCb.addEventListener("change", () => {
+                if (selectAllCb.checked) {
+                    items.forEach(([key]) => this.uiState.getSelected().add(key));
+                } else {
+                    items.forEach(([key]) => this.uiState.getSelected().delete(key));
                 }
-            }
+                this.renderList();
+            });
         }
 
-    }
-
-    private renderBulkOperations(container: HTMLElement, root: HTMLElement) {
-        const bulkControls = container.createDiv({ cls: "snipsy-section snipsy-bulk-operations" });
-        new Setting(bulkControls)
-            .setHeading()
-                .setName("Bulk operations");
-
-        const selectedCount = this.uiState.getSelected().size;
-        
-        new Setting(bulkControls)
-            .setName(`Selected: ${selectedCount} snippet${selectedCount === 1 ? '' : 's'}`)
-            .setDesc("Perform actions on selected snippets")
-            .addButton((btn) => {
-                 
-                btn.setButtonText("Move to…");
-                btn.onClick(() => {
-                    const groups = this.groupManager.allGroupsFrom(this.plugin.settings.snippets);
-                    const modal = new GroupPickerModal(this.app, {
-                        title: "Move to group:",
-                        groups,
-                        allowUngrouped: true
-                    });
-                    modal.onSubmit = (targetGroup) => {
-                        if (targetGroup === null) return;
-                        void this.moveSelectedSnippets(root, targetGroup);
-                    };
-                    modal.open();
-                });
-            })
-            .addButton((btn) => {
-                btn.setButtonText("Delete selected");
-                btn.onClick(() => {
-                    const n = this.uiState.getSelected().size;
-                    const modal = new ConfirmModal(this.app, {
-                        title: "Delete snippets",
-                        message: `Delete ${n} snippet(s)?`,
-                        confirmText: "Delete",
-                        onConfirm: async () => {
-                            for (const key of this.uiState.getSelected()) {
-                                delete this.plugin.settings.snippets[key];
-                            }
-                            await this.plugin.saveSettings();
-                            this.uiState.setSelected(new Set());
-                            this.renderSnippetList(root);
-                            new Notice(`Deleted ${n} snippet(s).`);
-                        }
-                    });
-                    modal.open();
-                });
+        const renameBtn = actions.createEl("button", {
+            cls: "snippet-action",
+            attr: { type: "button", "aria-label": `Rename group ${title}` },
+        });
+        setIcon(renameBtn, "pencil");
+        renameBtn.addEventListener("click", (e) => {
+            e.stopPropagation();
+            const modal = new TextPromptModal(this.app, {
+                title: "Rename group:",
+                initial: title,
+                validate: (v) => {
+                    const trimmed = v.trim();
+                    if (!trimmed) return "Group name cannot be empty";
+                    if (!slugifyGroup(trimmed))
+                        return "Group name must contain at least one letter or number";
+                    return null;
+                },
+                onSubmit: (newTitle) => {
+                    void this.renameGroup(group, title, items, isOpen, newTitle);
+                },
             });
+            modal.open();
+        });
+
+        const deleteBtn = actions.createEl("button", {
+            cls: "snippet-action is-danger",
+            attr: { type: "button", "aria-label": `Delete group ${title}` },
+        });
+        setIcon(deleteBtn, "trash");
+        deleteBtn.addEventListener("click", (e) => {
+            e.stopPropagation();
+            const modal = new ConfirmModal(this.app, {
+                title: "Delete group",
+                message: `Delete group "${title}" with ${items.length} snippet(s)?`,
+                confirmText: "Delete",
+                onConfirm: async () => {
+                    for (const [key] of items) {
+                        delete this.plugin.settings.snippets[key];
+                    }
+                    await this.plugin.saveSettings();
+                    this.uiState.getGroupOpen().delete(group);
+                    this.discardEditIfMissing();
+                    this.renderList();
+                    new Notice(`Deleted ${items.length} snippet(s) from "${title}".`);
+                },
+            });
+            modal.open();
+        });
+
+        if (isOpen) {
+            const content = groupEl.createDiv({ cls: "group-content" });
+            for (const [key, replacement] of items) {
+                this.renderSnippetRow(content, key, replacement);
+            }
+        }
     }
 
-    private async moveSelectedSnippets(root: HTMLElement, targetGroup: string) {
+    private renderSnippetRow(content: HTMLElement, key: string, replacement: string) {
+        const { name: triggerName } = splitKey(key);
+        const editing = this.uiState.isEditing(key);
+
+        const row = content.createDiv({
+            cls: `snippet-row${editing ? " is-editing" : ""}`,
+        });
+
+        if (editing) {
+            this.renderEditForm(row, key, triggerName, replacement);
+            return;
+        }
+
+        // Trigger column: checkbox + name in selection mode, name only
+        // otherwise. The grid layout (`.snippet-row`) is 3 columns:
+        // trigger / replacement / actions — so we always render exactly
+        // one element here.
+        const triggerCell = row.createDiv({ cls: "snippet-trigger" });
+        if (this.uiState.getSelectionMode()) {
+            const cb = triggerCell.createEl("input", {
+                type: "checkbox",
+                attr: { "aria-label": `Select snippet ${triggerName}` },
+            });
+            cb.checked = this.uiState.getSelected().has(key);
+            if (cb.checked) row.addClass("is-selected");
+            cb.addEventListener("change", () => {
+                if (cb.checked) this.uiState.getSelected().add(key);
+                else this.uiState.getSelected().delete(key);
+                this.updateBulkBar();
+                row.toggleClass("is-selected", cb.checked);
+            });
+            triggerCell.createSpan({ text: ` ${triggerName}` });
+        } else {
+            triggerCell.setText(triggerName);
+        }
+
+        const preview = row.createDiv({ cls: "snippet-replacement" });
+        preview.createSpan({ cls: "arrow", text: "→" });
+        preview.createSpan({ text: replacement || "" });
+
+        const actionsContainer = row.createDiv({ cls: "snippet-actions" });
+
+        const editBtn = actionsContainer.createEl("button", {
+            cls: "snippet-action",
+            attr: { type: "button", "aria-label": `Edit snippet ${triggerName}` },
+        });
+        setIcon(editBtn, "pencil");
+        editBtn.addEventListener("click", () => this.beginEdit(key, triggerName, replacement));
+
+        const delBtn = actionsContainer.createEl("button", {
+            cls: "snippet-action is-danger",
+            attr: { type: "button", "aria-label": `Delete snippet ${triggerName}` },
+        });
+        setIcon(delBtn, "trash");
+        delBtn.addEventListener("click", () => {
+            const modal = new ConfirmModal(this.app, {
+                title: "Delete snippet",
+                message: `Delete snippet "${triggerName}"?`,
+                confirmText: "Delete",
+                onConfirm: async () => {
+                    delete this.plugin.settings.snippets[key];
+                    await this.plugin.saveSettings();
+                    if (this.uiState.isEditing(key)) this.uiState.setEditing(null, null);
+                    this.uiState.getSelected().delete(key);
+                    this.renderList();
+                },
+            });
+            modal.open();
+        });
+    }
+
+    private renderEditForm(row: HTMLElement, key: string, triggerName: string, replacement: string) {
+        const draft = this.uiState.getEditingDraft() ?? { triggerName, replacement };
+
+        const form = row.createDiv({ cls: "snippet-edit" });
+
+        const triggerField = form.createDiv({ cls: "field" });
+        triggerField.createEl("label", { text: "Trigger" });
+        const triggerInput = triggerField.createEl("input", {
+            type: "text",
+            attr: { "aria-label": "Snippet trigger" },
+        });
+        triggerInput.value = draft.triggerName;
+        // Input mutates the live draft in UIStateManager; no re-render
+        // until save. This is the core of B-021's fix.
+        triggerInput.addEventListener("input", () => {
+            draft.triggerName = triggerInput.value;
+        });
+
+        const replacementField = form.createDiv({ cls: "field is-full" });
+        replacementField.createEl("label", { text: "Replacement" });
+        const replacementInput = replacementField.createEl("textarea", {
+            attr: { "aria-label": "Snippet replacement", rows: "4" },
+        });
+        replacementInput.value = draft.replacement;
+        replacementInput.addEventListener("input", () => {
+            draft.replacement = replacementInput.value;
+        });
+
+        const actions = form.createDiv({ cls: "actions" });
+        const cancelBtn = actions.createEl("button", {
+            cls: "snippet-action",
+            text: "Cancel",
+            attr: { type: "button" },
+        });
+        cancelBtn.addEventListener("click", () => {
+            this.uiState.setEditing(null, null);
+            this.renderList();
+        });
+
+        const saveBtn = actions.createEl("button", {
+            cls: "snippet-action mod-cta",
+            text: "Save",
+            attr: { type: "button" },
+        });
+        saveBtn.addEventListener("click", () => {
+            void this.saveEdit(key);
+        });
+
+        // Focus the trigger on entry. We schedule this so the input is
+        // attached to the document before `focus()` fires.
+        if (!triggerInput.matches(":focus")) {
+            window.setTimeout(() => triggerInput.focus(), 0);
+        }
+    }
+
+    private beginEdit(key: string, triggerName: string, replacement: string) {
+        // Single-edit-mode: opening a second row discards the prior
+        // unsaved draft. The previous behavior re-rendered the list and
+        // wiped the user's typing anyway (B-021); this is at least
+        // explicit and predictable.
+        this.uiState.setEditing(key, { triggerName, replacement });
+        this.renderList();
+    }
+
+    private async saveEdit(originalKey: string) {
+        const draft = this.uiState.getEditingDraft();
+        if (!draft) return;
+
+        const newTriggerName = draft.triggerName.trim();
+        const newReplacement = draft.replacement;
+
+        const normalized = normalizeTrigger(newTriggerName);
+        if (isBadTrigger(normalized)) {
+            new Notice("Invalid trigger: contains separators or is empty");
+            return;
+        }
+        if (newReplacement.length === 0) {
+            new Notice("Replacement cannot be empty");
+            return;
+        }
+
+        const { group: grp } = splitKey(originalKey);
+        const newKey = joinKey(grp, normalized);
+        if (hasTriggerCollision(this.plugin.settings, normalized, originalKey)) {
+            new Notice(`Trigger "${normalized}" already exists in another group`);
+            return;
+        }
+
+        try {
+            if (newKey !== originalKey) {
+                const result = this.groupManager.safeRenameKey(
+                    this.plugin.settings.snippets,
+                    originalKey,
+                    newKey,
+                );
+                if (!result.ok) {
+                    new Notice(result.reason || "Failed to rename");
+                    return;
+                }
+                if (this.uiState.getSelected().has(originalKey)) {
+                    this.uiState.getSelected().delete(originalKey);
+                    this.uiState.getSelected().add(newKey);
+                }
+            }
+            this.plugin.settings.snippets[newKey] = newReplacement;
+            await this.plugin.saveSettings();
+            this.uiState.setEditing(null, null);
+            this.renderList();
+        } catch {
+            new Notice("Failed to save changes");
+        }
+    }
+
+    /** Called after destructive operations (delete group / bulk delete)
+     *  to drop the editing pointer if the snippet it referenced is gone. */
+    private discardEditIfMissing() {
+        const editingKey = this.uiState.getEditingKey();
+        if (editingKey && this.plugin.settings.snippets[editingKey] === undefined) {
+            this.uiState.setEditing(null, null);
+        }
+    }
+
+    private async moveSelectedSnippets(targetGroup: string) {
         const keys = Array.from(this.uiState.getSelected());
         if (keys.length === 0) return;
 
-        const { moved, skipped } = this.groupManager.bulkMoveKeys(this.plugin.settings.snippets, targetGroup, keys);
+        const { moved, skipped } = this.groupManager.bulkMoveKeys(
+            this.plugin.settings.snippets,
+            targetGroup,
+            keys,
+        );
         if (moved === 0) {
             new Notice(`Moved 0 item(s)${skipped ? `, skipped ${skipped} (conflicts)` : ""}.`);
             return;
@@ -404,7 +577,8 @@ export class SnippetsTab {
         try {
             await this.plugin.saveSettings();
             this.uiState.setSelected(new Set());
-            this.renderSnippetList(root);
+            this.discardEditIfMissing();
+            this.renderList();
             new Notice(`Moved ${moved} item(s)${skipped ? `, skipped ${skipped} (conflicts)` : ""}.`);
         } catch {
             new Notice("Failed to move snippets");
@@ -412,12 +586,11 @@ export class SnippetsTab {
     }
 
     private async renameGroup(
-        root: HTMLElement,
         group: string,
         title: string,
         items: Array<[string, string]>,
         isOpen: boolean,
-        newTitle: string
+        newTitle: string,
     ) {
         if (!newTitle || newTitle === title) return;
 
@@ -427,7 +600,7 @@ export class SnippetsTab {
         const { moved, skipped } = this.groupManager.bulkMoveKeys(
             this.plugin.settings.snippets,
             newSlug,
-            items.map(([k]) => k)
+            items.map(([k]) => k),
         );
         if (moved === 0) {
             new Notice(`Renamed group failed: no snippets moved${skipped ? `, skipped ${skipped}` : ""}.`);
@@ -438,14 +611,17 @@ export class SnippetsTab {
             await this.plugin.saveSettings();
             this.uiState.setGroupOpen(newSlug, isOpen);
             this.uiState.getGroupOpen().delete(group);
-            this.renderSnippetList(root);
-            const groupName = newSlug === "" ? "Ungrouped" : this.groupManager.displayGroupTitle(newSlug);
-            new Notice(`Renamed group to "${groupName}" (${moved} moved${skipped ? `, skipped ${skipped}` : ""}).`);
+            this.discardEditIfMissing();
+            this.renderList();
+            const groupName =
+                newSlug === "" ? "Ungrouped" : this.groupManager.displayGroupTitle(newSlug);
+            new Notice(
+                `Renamed group to "${groupName}" (${moved} moved${skipped ? `, skipped ${skipped}` : ""}).`,
+            );
         } catch {
             new Notice("Failed to rename group");
         }
     }
-
 
     private showAddSnippetModal() {
         const modal = new AddSnippetModal(this.app, async (snippet) => {
@@ -464,160 +640,16 @@ export class SnippetsTab {
                     new Notice(`Snippet "${normalizedTrigger}" already exists`);
                     return;
                 }
-
                 if (hasTriggerCollision(this.plugin.settings, normalizedTrigger, key)) {
                     new Notice(`Trigger "${normalizedTrigger}" already exists in another group`);
                     return;
                 }
-                
+
                 this.plugin.settings.snippets[key] = snippet.replacement;
                 await this.plugin.saveSettings();
-                
-                // Refresh the list
-                const root = activeDocument.querySelector('.snipsidian-settings');
-                if (root) {
-                    this.renderSnippetList(root as HTMLElement);
-                }
+                this.renderList();
             }
         });
         modal.open();
-    }
-
-    private enterEditMode(row: Setting, trigger: string, triggerName: string, replacement: string, editBtn: HTMLButtonElement) {
-        // Clear existing controls
-        row.controlEl.empty();
-        
-        // Get the actual replacement from settings if it's not provided
-        const actualReplacement = replacement || this.plugin.settings.snippets[trigger] || "";
-        
-        // Add trigger input
-        const triggerInput = row.controlEl.createEl("input", {
-            type: "text",
-            placeholder: "Trigger",
-            cls: "snippet-edit-input"
-        });
-        triggerInput.value = triggerName || "";
-        
-        // Add replacement textarea
-        const replacementInput = row.controlEl.createEl("textarea", {
-            placeholder: "Replacement",
-            cls: "snippet-edit-textarea"
-        });
-        replacementInput.value = actualReplacement;
-        
-        // Add action buttons
-        const actionsContainer = row.controlEl.createDiv({ cls: "snippet-actions" });
-        
-        const saveBtn = actionsContainer.createEl("button", { 
-            text: "💾", 
-            cls: "snippet-action save-btn",
-            title: "Save changes"
-        });
-        
-        const cancelBtn = actionsContainer.createEl("button", { 
-            text: "Cancel", 
-            cls: "snippet-action cancel-btn",
-            title: "Cancel editing"
-        });
-        
-        // Update edit button
-        editBtn.empty();
-        editBtn.createSpan({ text: "💾" });
-        editBtn.title = "Save changes";
-        
-        // Store references for save/cancel
-        (row as SettingWithEditData).editData = {
-            trigger,
-            triggerName,
-            replacement: actualReplacement,
-            triggerInput,
-            replacementInput,
-            saveBtn,
-            cancelBtn,
-            editBtn
-        };
-        
-        // Add event handlers
-        saveBtn.onclick = () => {
-            const root = activeDocument.querySelector('.snipsidian-settings');
-            if (root) {
-                void this.saveSnippetChanges(row, trigger, triggerName, replacement, root as HTMLElement);
-            }
-        };
-        
-        cancelBtn.onclick = () => {
-            this.cancelEditMode(row, editBtn);
-        };
-    }
-
-    private async saveSnippetChanges(row: Setting, originalTrigger: string, _originalTriggerName: string, _originalReplacement: string, root: HTMLElement) {
-        const editData = (row as SettingWithEditData).editData;
-        if (!editData) return;
-        
-        const newTriggerName = editData.triggerInput.value.trim();
-        const newReplacement = editData.replacementInput.value;
-        
-        // Validate trigger
-        const normalized = normalizeTrigger(newTriggerName);
-        if (isBadTrigger(normalized)) {
-            new Notice("Invalid trigger: contains separators or is empty");
-            return;
-        }
-
-        if (newReplacement.length === 0) {
-            new Notice("Replacement cannot be empty");
-            return;
-        }
-        
-        // Check if trigger changed
-        const { group: grp } = splitKey(originalTrigger);
-        const newKey = joinKey(grp, normalized);
-        if (hasTriggerCollision(this.plugin.settings, normalized, originalTrigger)) {
-            new Notice(`Trigger "${normalized}" already exists in another group`);
-            return;
-        }
-        
-        try {
-            // Update snippet data
-            if (newKey !== originalTrigger) {
-                // Trigger changed - need to rename
-                const result = this.groupManager.safeRenameKey(this.plugin.settings.snippets, originalTrigger, newKey);
-                if (!result.ok) {
-                    new Notice(result.reason || "Failed to rename");
-                    return;
-                }
-                
-                // Update selection
-                if (this.uiState.getSelected().has(originalTrigger)) {
-                    this.uiState.getSelected().delete(originalTrigger);
-                    this.uiState.getSelected().add(newKey);
-                }
-            }
-            
-            // Update replacement
-            this.plugin.settings.snippets[newKey] = newReplacement;
-            
-            await this.plugin.saveSettings();
-            this.renderSnippetList(root);
-            
-        } catch {
-            new Notice("Failed to save changes");
-        }
-    }
-
-    private cancelEditMode(row: Setting, editBtn: HTMLButtonElement) {
-        // Reset edit button
-        editBtn.empty();
-        editBtn.createSpan({ text: "✏️" });
-        editBtn.title = "Edit snippet";
-        
-        // Clear edit data
-        delete (row as SettingWithEditData).editData;
-        
-        // Re-render the snippet list to return to normal view
-        const root = activeDocument.querySelector('.snipsidian-settings') as HTMLElement;
-        if (root) {
-            this.renderSnippetList(root);
-        }
     }
 }

--- a/src/ui/utils/ui-state.test.ts
+++ b/src/ui/utils/ui-state.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { UIStateManager } from "./ui-state";
+import type { SnipSidianSettings } from "../../types";
+
+/**
+ * ADR-0005: every fix ships with a regression test that fails before
+ * the fix. These tests pin the contract the SnippetsTab redesign
+ * depends on for B-021 (re-renders destroying in-progress edits).
+ *
+ * Why these specific tests, not coverage chasing:
+ * - tab persistence migration: orphans users on upgrade if broken
+ * - edit state lift: load-bearing for B-021 — re-renders MUST preserve
+ *   the live draft reference so input handlers keep mutating the same
+ *   object
+ */
+
+function makeSettings(overrides: Partial<SnipSidianSettings> = {}): SnipSidianSettings {
+    return {
+        snippets: {},
+        ...overrides,
+    };
+}
+
+describe("UIStateManager — tab migration (1.0.x → 1.1.0)", () => {
+    it("preserves stored new-IA tab ids unchanged", () => {
+        const settings = makeSettings({ ui: { activeTab: "packages" } });
+        const ui = new UIStateManager(settings);
+        expect(ui.loadActiveTab()).toBe("packages");
+    });
+
+    it("migrates pre-1.1.0 'basic' to 'general'", () => {
+        const settings = makeSettings({ ui: { activeTab: "basic" } });
+        const ui = new UIStateManager(settings);
+        expect(ui.loadActiveTab()).toBe("general");
+    });
+
+    it("migrates pre-1.1.0 'community' to 'packages'", () => {
+        const settings = makeSettings({ ui: { activeTab: "community" } });
+        const ui = new UIStateManager(settings);
+        expect(ui.loadActiveTab()).toBe("packages");
+    });
+
+    it("migrates pre-1.1.0 'feedback' to 'about'", () => {
+        const settings = makeSettings({ ui: { activeTab: "feedback" } });
+        const ui = new UIStateManager(settings);
+        expect(ui.loadActiveTab()).toBe("about");
+    });
+
+    it("keeps pre-1.1.0 'snippets' as 'snippets'", () => {
+        const settings = makeSettings({ ui: { activeTab: "snippets" } });
+        const ui = new UIStateManager(settings);
+        expect(ui.loadActiveTab()).toBe("snippets");
+    });
+
+    it("falls back to landing tab when stored value is unknown", () => {
+        const settings = makeSettings({ ui: { activeTab: "wat-is-this" } });
+        const ui = new UIStateManager(settings);
+        expect(ui.loadActiveTab()).toBe("snippets");
+    });
+
+    it("falls back to landing tab on first launch (no stored value)", () => {
+        const settings = makeSettings();
+        const ui = new UIStateManager(settings);
+        expect(ui.loadActiveTab()).toBe("snippets");
+    });
+
+    it("writes migrated value back so subsequent reads hit the happy path", () => {
+        const settings = makeSettings({ ui: { activeTab: "community" } });
+        const ui = new UIStateManager(settings);
+        ui.loadActiveTab();
+        expect(settings.ui!.activeTab).toBe("packages");
+    });
+});
+
+describe("UIStateManager — inline edit state (B-021 contract)", () => {
+    let ui: UIStateManager;
+
+    beforeEach(() => {
+        ui = new UIStateManager(makeSettings());
+    });
+
+    it("starts with no row in edit", () => {
+        expect(ui.getEditingKey()).toBeNull();
+        expect(ui.getEditingDraft()).toBeNull();
+        expect(ui.isEditing("anything")).toBe(false);
+    });
+
+    it("setEditing stores key and draft atomically", () => {
+        ui.setEditing("arrows/right", { triggerName: "right", replacement: "→" });
+        expect(ui.getEditingKey()).toBe("arrows/right");
+        expect(ui.getEditingDraft()).toEqual({ triggerName: "right", replacement: "→" });
+    });
+
+    it("isEditing matches only the active key", () => {
+        ui.setEditing("a/b", { triggerName: "b", replacement: "x" });
+        expect(ui.isEditing("a/b")).toBe(true);
+        expect(ui.isEditing("a/c")).toBe(false);
+        expect(ui.isEditing("")).toBe(false);
+    });
+
+    it("getEditingDraft returns a live reference (not a copy)", () => {
+        // This is the load-bearing contract for B-021. The SnippetsTab
+        // edit form binds input.oninput to `draft.triggerName = ...`.
+        // If getEditingDraft returned a copy, re-renders would read a
+        // stale value and lose user keystrokes.
+        ui.setEditing("g/k", { triggerName: "k", replacement: "v" });
+        const draft = ui.getEditingDraft();
+        expect(draft).not.toBeNull();
+        draft!.triggerName = "k2";
+        expect(ui.getEditingDraft()!.triggerName).toBe("k2");
+    });
+
+    it("setEditing(null, null) clears state cleanly", () => {
+        ui.setEditing("g/k", { triggerName: "k", replacement: "v" });
+        ui.setEditing(null, null);
+        expect(ui.getEditingKey()).toBeNull();
+        expect(ui.getEditingDraft()).toBeNull();
+        expect(ui.isEditing("g/k")).toBe(false);
+    });
+
+    it("switching edit target overwrites the previous draft", () => {
+        // Single-edit-mode: opening edit on row B while A is editing
+        // discards A's draft. Verifies the design choice.
+        ui.setEditing("a/x", { triggerName: "x", replacement: "1" });
+        ui.setEditing("b/y", { triggerName: "y", replacement: "2" });
+        expect(ui.getEditingKey()).toBe("b/y");
+        expect(ui.getEditingDraft()).toEqual({ triggerName: "y", replacement: "2" });
+        expect(ui.isEditing("a/x")).toBe(false);
+    });
+});

--- a/src/ui/utils/ui-state.ts
+++ b/src/ui/utils/ui-state.ts
@@ -29,6 +29,13 @@ const VALID_TAB_IDS: ReadonlySet<TabId> = new Set<TabId>([
  *  `settings.ui` is mutated. May be sync (returns void) or async. */
 type Persist = () => void | Promise<void>;
 
+/** Draft of an in-progress inline edit. Lives in memory only (not
+ *  persisted) — exiting Settings discards unsaved changes. */
+export interface EditDraft {
+    triggerName: string;
+    replacement: string;
+}
+
 export class UIStateManager {
     /** Default landing tab. "Snippets" because that's where day-to-day
      *  work happens — most users open Settings to manage their library
@@ -38,6 +45,13 @@ export class UIStateManager {
     private searchQuery = "";
     private selectionMode = false;
     private selected = new Set<string>();
+
+    /** Single-edit-mode: only one snippet row can be in edit at a time.
+     *  Lifted to UIStateManager so `renderSnippetList()` re-renders don't
+     *  destroy the in-flight edit (B-021). `editingKey` is the snippet
+     *  key (folder/trigger); `editingDraft` holds the unsaved values. */
+    private editingKey: string | null = null;
+    private editingDraft: EditDraft | null = null;
 
     /** Debounce timer for `setGroupOpen` — bulk-expand triggers N saves in
      *  quick succession; we coalesce into one. */
@@ -153,5 +167,34 @@ export class UIStateManager {
 
     setSelected(selected: Set<string>) {
         this.selected = selected;
+    }
+
+    // ---- Inline edit state ----
+    /** Returns the snippet key currently in edit mode, or `null` if no
+     *  row is being edited. */
+    getEditingKey(): string | null {
+        return this.editingKey;
+    }
+
+    /** Returns the current edit draft, or `null` if no row is being
+     *  edited. Returned object is the live reference — callers may
+     *  mutate it directly to track input changes without forcing a
+     *  re-render. */
+    getEditingDraft(): EditDraft | null {
+        return this.editingDraft;
+    }
+
+    /** Enter edit mode for a given snippet key. Pass `null` to exit
+     *  edit mode (after save/cancel). The draft starts as a copy of the
+     *  current trigger/replacement and is mutated in place by input
+     *  handlers. */
+    setEditing(key: string | null, draft: EditDraft | null) {
+        this.editingKey = key;
+        this.editingDraft = draft;
+    }
+
+    /** True when the given key is the currently edited row. */
+    isEditing(key: string): boolean {
+        return this.editingKey === key;
     }
 }

--- a/styles.css
+++ b/styles.css
@@ -118,6 +118,22 @@
   color: var(--snipsy-on-accent);
 }
 
+/* Utility — used by tab JS to hide/show without setting inline
+   styles (Obsidian's `no-static-styles-assignment` lint rule forbids
+   `el.style.display = "none"`). Keep this near the top so anything can
+   use it. */
+.snipsidian-settings .is-hidden { display: none !important; }
+
+/* ---- Snippets-tab heading ---- */
+/* Real <h3> per accessibility audit (B-091) — `Setting().setHeading()`
+   renders a styled div, which is invisible to screen readers as a
+   structural heading. */
+.snipsidian-settings .snipsy-tab-heading {
+  font-size: 16px;
+  font-weight: 600;
+  margin: 4px 0 12px;
+}
+
 /* ---- Search bar ---- */
 .snipsidian-settings .snipsy-search {
   position: relative;
@@ -125,6 +141,7 @@
 }
 .snipsidian-settings .snipsy-search input {
   padding-left: 30px;
+  width: 100%;
 }
 .snipsidian-settings .snipsy-search .snipsy-search-icon {
   position: absolute;
@@ -133,6 +150,23 @@
   transform: translateY(-50%);
   color: var(--snipsy-text-faint);
   pointer-events: none;
+}
+
+/* ---- Snippet toolbar (search + actions row above the list) ---- */
+.snipsidian-settings .snipsy-snippet-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
+/* Filter count badge (B-099) — only rendered when a search query is
+   active. Tells the user how many results their query returned without
+   forcing them to scroll the list. */
+.snipsidian-settings .snipsy-filter-count {
+  font-size: 12px;
+  color: var(--snipsy-text-faint);
+  white-space: nowrap;
 }
 
 /* ---- Snippet list ---- */


### PR DESCRIPTION
## Summary

Rewrites `SnippetsTab` to the redesign spec: toolbar pattern, sticky bulk bar, single-edit-mode, `setIcon()` icons. Lifts inline-edit state to `UIStateManager` so re-renders no longer destroy in-progress edits (the keystone B-021 fix).

## Backlog items closed

- **B-021** — Inline edit state survives re-renders. `editingKey` + `editingDraft` live in `UIStateManager`; the form binds `oninput` to the live draft reference so renders never observe a stale value. Single-edit-mode: opening row B while A is editing discards A's draft (explicit > silent data loss).
- **B-082 (partial)** — Emoji buttons (`▶/▼/✏️/🗑️/💾`) replaced with `setIcon()` + per-row `aria-label` (e.g. "Edit snippet :hello", "Rename group arrows"). Group chevron uses CSS rotation, not glyph swap.
- **B-099** — Search result-count badge ("N of M"), shown only when query is non-empty.
- **B-091 (partial)** — `Setting().setHeading()` styled-div → real `<h3>` (screen-reader-visible heading).
- **B-041** — Removed redundant `.setCta()` on the "Add snippet" outer wrapper; one CTA per tab.
- **A-001 (partial)** — Per-row `aria-label`s for all action buttons.

## Notable changes

- Toolbar replaces the four `Setting().setHeading()` blocks + two toggle rows: search + filter count badge + Select/Done + Expand/Collapse all + single CTA "Add snippet".
- Sticky `.snipsy-bulk-bar` mounted once, toggled by selection state (was being re-mounted as a `Setting` row on every selection change).
- Search input persists across re-renders — focus and cursor position survive typing.
- Empty-state block for both "no snippets" and "no results match filter".

## Tests

14 boundary tests for `UIStateManager` per [ADR-0005](.claude/brain/decisions/0005-test-philosophy.md): tab migration (1.0.x → 1.1.0) and the edit-state contract. Specifically pins **`getEditingDraft()` returns a live reference** — that's the load-bearing assertion for B-021's fix.

- `npm test` — 249/249 pass
- Coverage — 92.66% lines / 86.67% branches (above thresholds)
- `npm run lint` — clean
- `npx tsc --noEmit` — clean
- `npm run build` — 181.7kb bundle

## Test plan

- [ ] Open Settings → Snippets, type in the search box: focus is preserved, result-count badge updates live
- [ ] Click Edit on row A, start typing, click Edit on row B → A's draft is discarded, B opens with its current values
- [ ] Click Edit, type a new trigger, click Save → row updates and re-renders cleanly
- [ ] Toggle "Select", check a few rows, "Move to group" / "Delete" / "Clear" all work; bulk bar disappears when selection is cleared
- [ ] Expand all → collapses to "Collapse all"; group chevrons rotate
- [ ] Tab through with keyboard: all action buttons have meaningful aria-labels
- [ ] Empty state: clear all snippets → "Add your first snippet" message; or filter to no matches → "No snippets match" message

Refs: ADR-0006 sub-PR 4d, HANDOFF.md §2b.

🤖 Generated with [Claude Code](https://claude.com/claude-code)