### PR TITLE
feat(ui): 1.1.0 BasicTab strip CTAs + ImportPreviewModal (PR 4e)

### DIFF
--- a/src/services/import-diff.test.ts
+++ b/src/services/import-diff.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from "vitest";
+import { computeImportDiff } from "./import-diff";
+
+/**
+ * ADR-0005: tests pin the contract that `ImportPreviewModal` relies on
+ * to show the user what merge vs replace will actually do. The
+ * load-bearing assertion is the `removed` list — that's the difference
+ * between merge (safe) and replace (destructive).
+ */
+
+describe("computeImportDiff", () => {
+    it("classifies a new key as added", () => {
+        const diff = computeImportDiff({}, { ":hi": "Hello" });
+        expect(diff.added).toEqual([{ key: ":hi", value: "Hello" }]);
+        expect(diff.conflicts).toEqual([]);
+        expect(diff.removed).toEqual([]);
+        expect(diff.unchangedCount).toBe(0);
+    });
+
+    it("classifies a same-value key as unchanged (not a conflict)", () => {
+        const diff = computeImportDiff({ ":hi": "Hello" }, { ":hi": "Hello" });
+        expect(diff.added).toEqual([]);
+        expect(diff.conflicts).toEqual([]);
+        expect(diff.removed).toEqual([]);
+        expect(diff.unchangedCount).toBe(1);
+    });
+
+    it("classifies a different-value key as a conflict with both sides", () => {
+        const diff = computeImportDiff({ ":hi": "Hello" }, { ":hi": "Hi" });
+        expect(diff.added).toEqual([]);
+        expect(diff.conflicts).toEqual([
+            { key: ":hi", current: "Hello", incoming: "Hi" },
+        ]);
+        expect(diff.removed).toEqual([]);
+    });
+
+    it("flags current-only keys as removed (the replace-mode warning surface)", () => {
+        // This is the load-bearing assertion: without `removed`, a user
+        // who picks "Replace all" has no way to see they're about to
+        // delete N snippets. This was the B-038 silent-wipe bug.
+        const diff = computeImportDiff(
+            { ":a": "1", ":b": "2", ":c": "3" },
+            { ":a": "1" },
+        );
+        expect(diff.removed).toEqual([
+            { key: ":b", value: "2" },
+            { key: ":c", value: "3" },
+        ]);
+    });
+
+    it("treats empty-string values as real values, not absence", () => {
+        // The `in` operator differentiates {a:""} from {}, but
+        // `current[key] !== value` could mishandle empties if we used
+        // truthy checks. Pin the boundary.
+        const diff = computeImportDiff({ ":x": "" }, { ":x": "" });
+        expect(diff.unchangedCount).toBe(1);
+        expect(diff.conflicts).toEqual([]);
+    });
+
+    it("handles a clean replace (no overlap)", () => {
+        const diff = computeImportDiff(
+            { ":a": "A", ":b": "B" },
+            { ":c": "C", ":d": "D" },
+        );
+        expect(diff.added.map((x) => x.key)).toEqual([":c", ":d"]);
+        expect(diff.removed.map((x) => x.key)).toEqual([":a", ":b"]);
+        expect(diff.conflicts).toEqual([]);
+        expect(diff.unchangedCount).toBe(0);
+    });
+
+    it("returns results sorted by key (deterministic for snapshot tests)", () => {
+        const diff = computeImportDiff(
+            { "z/c": "C", "a/b": "B" },
+            { "z/c": "C2", "a/b": "B2", "m/x": "X" },
+        );
+        expect(diff.conflicts.map((x) => x.key)).toEqual(["a/b", "z/c"]);
+        expect(diff.added.map((x) => x.key)).toEqual(["m/x"]);
+    });
+
+    it("treats the empty-import edge case as a full delete", () => {
+        // A user dropping in `{}` should see every current snippet
+        // listed as removed — they're about to wipe everything.
+        const diff = computeImportDiff({ ":a": "A", ":b": "B" }, {});
+        expect(diff.added).toEqual([]);
+        expect(diff.removed.map((x) => x.key)).toEqual([":a", ":b"]);
+        expect(diff.unchangedCount).toBe(0);
+    });
+
+    it("treats the empty-current edge case as a fresh install", () => {
+        const diff = computeImportDiff({}, { ":a": "A", ":b": "B" });
+        expect(diff.added.map((x) => x.key)).toEqual([":a", ":b"]);
+        expect(diff.removed).toEqual([]);
+        expect(diff.conflicts).toEqual([]);
+    });
+
+    it("does not mutate either input", () => {
+        const current = { ":a": "A" };
+        const incoming = { ":a": "B" };
+        const currentSnapshot = JSON.stringify(current);
+        const incomingSnapshot = JSON.stringify(incoming);
+        computeImportDiff(current, incoming);
+        expect(JSON.stringify(current)).toBe(currentSnapshot);
+        expect(JSON.stringify(incoming)).toBe(incomingSnapshot);
+    });
+});

--- a/src/services/import-diff.ts
+++ b/src/services/import-diff.ts
@@ -1,0 +1,57 @@
+/**
+ * Pure diff between the current snippet library and a parsed import
+ * file. Used by `ImportPreviewModal` so the user can see what will
+ * change before committing — replaces the silent
+ * `settings.snippets = parsed; saveSettings()` that previously
+ * wiped people's libraries (B-038).
+ *
+ * Kept pure (no Obsidian, no DOM) so it can be unit-tested at the
+ * contract level per ADR-0005. The modal is responsible for
+ * rendering; the caller is responsible for the write.
+ */
+
+export interface ImportDiff {
+    /** Keys present in `incoming` but not in `current`. */
+    added: Array<{ key: string; value: string }>;
+    /** Keys in both, with different values. */
+    conflicts: Array<{ key: string; current: string; incoming: string }>;
+    /** Keys present in `current` but not in `incoming`. Only matters
+     *  for replace mode — in merge mode these are kept. */
+    removed: Array<{ key: string; value: string }>;
+    /** Keys in both, identical value. Counted, not enumerated. */
+    unchangedCount: number;
+}
+
+export function computeImportDiff(
+    current: Record<string, string>,
+    incoming: Record<string, string>,
+): ImportDiff {
+    const added: Array<{ key: string; value: string }> = [];
+    const conflicts: Array<{ key: string; current: string; incoming: string }> = [];
+    const removed: Array<{ key: string; value: string }> = [];
+    let unchangedCount = 0;
+
+    for (const [key, value] of Object.entries(incoming)) {
+        if (!(key in current)) {
+            added.push({ key, value });
+        } else if (current[key] !== value) {
+            conflicts.push({ key, current: current[key] ?? "", incoming: value });
+        } else {
+            unchangedCount++;
+        }
+    }
+
+    for (const [key, value] of Object.entries(current)) {
+        if (!(key in incoming)) {
+            removed.push({ key, value });
+        }
+    }
+
+    // Deterministic ordering so the modal list is stable across renders
+    // and snapshot tests are reliable.
+    added.sort((a, b) => a.key.localeCompare(b.key));
+    conflicts.sort((a, b) => a.key.localeCompare(b.key));
+    removed.sort((a, b) => a.key.localeCompare(b.key));
+
+    return { added, conflicts, removed, unchangedCount };
+}

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -389,6 +389,94 @@
 .modal.snipsy-install .diff-tag.is-new      { background: rgba(108, 197, 133, 0.15); color: var(--snipsy-success); }
 .modal.snipsy-install .diff-tag.is-replace  { background: rgba(232, 113, 106, 0.14); color: var(--snipsy-danger); }
 
+/* ---- Import preview modal (B-038 fix) ----
+   Replaces the old silent-wipe import. Merge/replace picker + diff
+   list. Replace mode shows `removed` rows in red as the destructive-
+   action affordance (designer Q5 — no second-confirm dialog). */
+.snipsidian-import-modal .snipsy-import-mode {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+.snipsidian-import-modal .snipsy-import-mode-option {
+  display: grid;
+  grid-template-columns: auto auto 1fr;
+  align-items: baseline;
+  gap: 8px;
+  padding: 6px 10px;
+  border: 1px solid var(--snipsy-divider);
+  border-radius: var(--snipsy-radius);
+  cursor: pointer;
+}
+.snipsidian-import-modal .snipsy-import-mode-hint {
+  font-size: 12px;
+  color: var(--snipsy-text-muted);
+}
+.snipsidian-import-modal .snipsy-import-mode-hint-danger {
+  color: var(--snipsy-danger);
+}
+.snipsidian-import-modal .snipsy-import-summary {
+  font-size: 13px;
+  color: var(--snipsy-text-muted);
+  margin: 8px 0;
+}
+.snipsidian-import-modal .snipsy-import-list {
+  max-height: 320px;
+  overflow-y: auto;
+  border: 1px solid var(--snipsy-divider);
+  border-radius: var(--snipsy-radius);
+  margin-bottom: 12px;
+}
+.snipsidian-import-modal .snipsy-import-row {
+  display: grid;
+  grid-template-columns: 64px minmax(80px, 200px) 1fr;
+  gap: 10px;
+  padding: 6px 10px;
+  border-top: 1px solid var(--snipsy-divider);
+  font-size: 12.5px;
+}
+.snipsidian-import-modal .snipsy-import-row:first-child { border-top: 0; }
+.snipsidian-import-modal .snipsy-import-tag {
+  font-size: 10.5px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  padding: 2px 6px;
+  border-radius: 3px;
+  width: fit-content;
+}
+.snipsidian-import-modal .snipsy-import-tag-new {
+  background: rgba(108, 197, 133, 0.15);
+  color: var(--snipsy-success);
+}
+.snipsidian-import-modal .snipsy-import-tag-update {
+  background: rgba(108, 162, 232, 0.15);
+  color: var(--snipsy-accent);
+}
+.snipsidian-import-modal .snipsy-import-tag-remove {
+  background: rgba(232, 113, 106, 0.14);
+  color: var(--snipsy-danger);
+}
+.snipsidian-import-modal .snipsy-import-key {
+  font-family: var(--snipsy-mono);
+  font-weight: 500;
+}
+.snipsidian-import-modal .snipsy-import-value {
+  font-family: var(--snipsy-mono);
+  color: var(--snipsy-text-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.snipsidian-import-modal .snipsy-import-more {
+  padding: 8px 10px;
+  font-size: 12px;
+  color: var(--snipsy-text-faint);
+  text-align: center;
+  border-top: 1px solid var(--snipsy-divider);
+}
+
 /* ---- Reduced motion ---- */
 /* Honour the user's OS preference (B-089 / a11y A-011). Transitions
    and animations are subtle in Snipsy, but vestibular-disorder users

--- a/src/ui/components/BasicTab.ts
+++ b/src/ui/components/BasicTab.ts
@@ -1,196 +1,233 @@
 import { App, Notice, Platform, Setting } from "obsidian";
 import type SnipSidianPlugin from "../../main";
 import { isRecordOfString } from "../../shared/guards";
+import { ImportPreviewModal } from "./Modals";
 
+/**
+ * General tab. Per the 1.1.0 redesign (HANDOFF §2c) every button here
+ * is a utility, not a primary action — so none get `.setCta()`. The
+ * old "8 CTAs in one tab" pattern made primary actions unreadable.
+ *
+ * Import flow no longer wipes the library silently (B-038). It now
+ * opens `ImportPreviewModal` with the parsed payload; the user picks
+ * merge vs replace and sees the diff before the write happens.
+ */
 export class BasicTab {
     constructor(
         private app: App,
-        private plugin: SnipSidianPlugin
+        private plugin: SnipSidianPlugin,
     ) {}
 
     render(root: HTMLElement) {
-        // Helper function for creating sections
-        const section = (title: string, hint?: string, specialClass?: string) => {
-            const wrap = root.createDiv({ cls: `snipsy-section ${specialClass || ""}` });
-            new Setting(wrap)
-                .setHeading()
-                .setName(title);
-            if (hint) wrap.createEl("p", { text: hint, cls: "snipsy-hint" });
-            return wrap;
+        // Real <h3>s per accessibility audit B-091. `Setting().setHeading()`
+        // emits a styled-div that screen readers don't pick up as a
+        // section heading.
+        const sectionHeading = (parent: HTMLElement, title: string, hint?: string) => {
+            parent.createEl("h3", { text: title, cls: "snipsy-tab-heading" });
+            if (hint) parent.createEl("p", { text: hint, cls: "snipsy-hint" });
         };
 
-        // Commands section
-        const commandsSection = section("Commands", "Configure hotkeys for Snipsy commands.", "snipsy-commands-section");
+        // ---- Commands ----
+        sectionHeading(root, "Commands", "Configure hotkeys for Snipsy commands.");
 
-        new Setting(commandsSection)
+        new Setting(root)
             .setName("Insert snippet")
             .setDesc("Open the snippet picker to insert snippets")
             .addButton((btn) =>
-                btn
-                    .setButtonText("Set hotkey")
-                    .setCta()
-                    .onClick(() => {
-                        // Open hotkey settings for the insert-snippet command
-                        this.app.setting.open();
-                        this.app.setting.openTabById("hotkeys");
-                        // Focus on our command
-                        window.setTimeout(() => {
-                            const hotkeyTab = activeDocument.querySelector('.setting-item[data-id="snipsidian:insert-snippet"]');
-                            if (hotkeyTab) {
-                                hotkeyTab.scrollIntoView({ behavior: 'smooth', block: 'center' });
-                            }
-                        }, 100);
-                    })
+                btn.setButtonText("Set hotkey").onClick(() => {
+                    this.openHotkeyTab("snipsidian:insert-snippet");
+                }),
             );
 
-        new Setting(commandsSection)
+        new Setting(root)
             .setName("Open settings")
             .setDesc("Quick access to plugin settings")
             .addButton((btn) =>
-                btn
-                    .setButtonText("Set hotkey")
-                    .setCta()
-                    .onClick(() => {
-                        // Open hotkey settings for the open-settings command
-                        this.app.setting.open();
-                        this.app.setting.openTabById("hotkeys");
-                        // Focus on our command
-                        window.setTimeout(() => {
-                            const hotkeyTab = activeDocument.querySelector('.setting-item[data-id="snipsidian:open-settings"]');
-                            if (hotkeyTab) {
-                                hotkeyTab.scrollIntoView({ behavior: 'smooth', block: 'center' });
-                            }
-                        }, 100);
-                    })
+                btn.setButtonText("Set hotkey").onClick(() => {
+                    this.openHotkeyTab("snipsidian:open-settings");
+                }),
             );
 
-        // Export/Import section
-        const exportSection = section("Export & Import", "Backup your snippets or share them between devices.", "snipsy-export-section");
+        // ---- Backup (export + import + reveal) ----
+        sectionHeading(
+            root,
+            "Backup",
+            "Export your snippets, restore from a backup, or open the data file.",
+        );
 
-        new Setting(exportSection)
+        new Setting(root)
             .setName("Export snippets")
             .setDesc("Download your snippets as a JSON file")
             .addButton((btn) =>
-                btn
-                    .setButtonText("Export JSON")
-                    .setCta()
-                    .onClick(() => {
-                        const data = JSON.stringify(this.plugin.settings.snippets, null, 2);
-                        const blob = new Blob([data], { type: "application/json" });
-                        const url = URL.createObjectURL(blob);
-                        const a = createEl("a");
-                        a.href = url;
-                        a.download = "snipsidian-snippets.json";
-                        a.click();
-                        URL.revokeObjectURL(url);
-                    })
+                btn.setButtonText("Export JSON").onClick(() => this.exportJson()),
             );
 
-        new Setting(exportSection)
+        new Setting(root)
             .setName("Import snippets")
-            .setDesc("Upload a JSON file to replace your current snippets")
+            .setDesc("Preview a JSON file before merging or replacing your library")
             .addButton((btn) =>
-                btn
-                    .setButtonText("Import JSON")
-                    .setCta()
-                    .onClick(() => {
-                        const input = createEl("input");
-                        input.type = "file";
-                        input.accept = ".json";
-                        input.onchange = async (e) => {
-                            const file = (e.target as HTMLInputElement).files?.[0];
-                            if (!file) return;
-
-                            try {
-                                const text = await file.text();
-                                const parsed: unknown = JSON.parse(text);
-                                if (!isRecordOfString(parsed)) {
-                                    new Notice("Invalid JSON: must be an object of { trigger: replacement } strings");
-                                    return;
-                                }
-                                this.plugin.settings.snippets = parsed;
-                                await this.plugin.saveSettings();
-                                new Notice("Snippets imported successfully");
-                            } catch (err) {
-                                new Notice(`Import failed: ${err instanceof Error ? err.message : String(err)}`);
-                            }
-                        };
-                        input.click();
-                    })
+                btn.setButtonText("Import JSON").onClick(() => this.startImport()),
             );
 
-        new Setting(exportSection)
+        new Setting(root)
             .setName("Reveal data file")
             .setDesc("Open the snippets data file in your file manager")
             .addButton((btn) =>
-                btn
-                    .setButtonText("Reveal")
-                    .setCta()
-                    .onClick(() => {
-                        try {
-                            if (Platform.isDesktop) {
-                                const adapter = this.app.vault.adapter as { getBasePath?: () => string };
-                                if (typeof adapter.getBasePath !== "function") throw new Error("Not supported on this platform");
-                                const base: string = adapter.getBasePath();
-                                const configDir: string = this.app.vault.configDir;
-                                const path = `${base}/${configDir}/plugins/snipsidian/data.json`;
-                                const electron = (window as { require?: (module: string) => { shell?: { showItemInFolder?: (path: string) => void } } }).require?.("electron");
-                                if (!electron?.shell?.showItemInFolder) throw new Error("Electron shell not available");
-                                electron.shell.showItemInFolder(path);
-                            } else {
-                                new Notice("File manager access is only available on desktop");
-                            }
-                        } catch (err) {
-                            new Notice(`Failed to reveal file: ${err instanceof Error ? err.message : String(err)}`);
-                        }
-                    })
+                btn.setButtonText("Reveal").onClick(() => this.revealDataFile()),
             );
 
-        // Help section
-        const helpSection = section("Help & Resources", "Learn more about Snipsy and text expansion.", "snipsy-help-section");
+        // ---- Help & Resources ----
+        sectionHeading(
+            root,
+            "Help & Resources",
+            "Documentation, demos, and external snippet catalogs.",
+        );
 
-        new Setting(helpSection)
+        new Setting(root)
             .setName("Documentation")
-            .setDesc("Visit the GitHub repository for documentation and examples")
+            .setDesc("GitHub repository — docs, examples, and source")
             .addButton((btn) =>
-                btn
-                    .setButtonText("Open GitHub")
-                    .setCta()
-                    .onClick(() => {
-                        window.open("https://github.com/Dimagious/snipsidian", "_blank", "noopener,noreferrer");
-                    })
+                btn.setButtonText("Open").onClick(() => {
+                    window.open(
+                        "https://github.com/Dimagious/snipsidian",
+                        "_blank",
+                        "noopener,noreferrer",
+                    );
+                }),
             );
 
-        new Setting(helpSection)
+        new Setting(root)
             .setName("Espanso hub")
-            .setDesc("Browse thousands of community-created packages")
+            .setDesc("Thousands of community-created packages")
             .addButton((btn) =>
-                btn
-                    .setButtonText("Browse packages")
-                    .setCta()
-                    .onClick(() => {
-                        window.open("https://hub.espanso.org/", "_blank", "noopener,noreferrer");
-                    })
+                btn.setButtonText("Open hub").onClick(() => {
+                    window.open(
+                        "https://hub.espanso.org/",
+                        "_blank",
+                        "noopener,noreferrer",
+                    );
+                }),
             );
 
-        new Setting(helpSection)
+        new Setting(root)
             .setName("Demo")
             .setDesc("See the plugin in action")
             .addButton((btn) =>
-                btn
-                    .setButtonText("View demo")
-                    .setCta()
-                    .onClick(() => {
-                        try {
-                            const adapter = this.app.vault.adapter as { getBasePath?: () => string };
-                            const base: string = adapter?.getBasePath?.() ?? "";
-                            const configDir: string = this.app.vault.configDir;
-                            const absPath = `${base}/${configDir}/plugins/snipsidian/docs/screens/espanso-demo.gif`;
-                            window.open(absPath, "_blank", "noopener,noreferrer");
-                        } catch (err) {
-                            new Notice(`Failed to open demo: ${err instanceof Error ? err.message : String(err)}`);
-                        }
-                    })
+                btn.setButtonText("View demo").onClick(() => this.openDemo()),
             );
+    }
+
+    private openHotkeyTab(commandId: string) {
+        this.app.setting.open();
+        this.app.setting.openTabById("hotkeys");
+        window.setTimeout(() => {
+            const hotkeyTab = activeDocument.querySelector(
+                `.setting-item[data-id="${commandId}"]`,
+            );
+            if (hotkeyTab) {
+                hotkeyTab.scrollIntoView({ behavior: "smooth", block: "center" });
+            }
+        }, 100);
+    }
+
+    private exportJson() {
+        const data = JSON.stringify(this.plugin.settings.snippets, null, 2);
+        const blob = new Blob([data], { type: "application/json" });
+        const url = URL.createObjectURL(blob);
+        const a = createEl("a");
+        a.href = url;
+        a.download = "snipsidian-snippets.json";
+        a.click();
+        URL.revokeObjectURL(url);
+    }
+
+    private startImport() {
+        const input = createEl("input");
+        input.type = "file";
+        input.accept = ".json";
+        input.onchange = async (e) => {
+            const file = (e.target as HTMLInputElement).files?.[0];
+            if (!file) return;
+
+            try {
+                const text = await file.text();
+                const parsed: unknown = JSON.parse(text);
+                if (!isRecordOfString(parsed)) {
+                    new Notice(
+                        "Invalid JSON: must be an object of { trigger: replacement } strings",
+                    );
+                    return;
+                }
+
+                new ImportPreviewModal(this.app, {
+                    current: this.plugin.settings.snippets,
+                    incoming: parsed,
+                    onConfirm: async (mode) => {
+                        // Caller owns the write per modal contract.
+                        this.plugin.settings.snippets =
+                            mode === "replace"
+                                ? parsed
+                                : { ...this.plugin.settings.snippets, ...parsed };
+                        await this.plugin.saveSettings();
+                        const count = Object.keys(parsed).length;
+                        new Notice(
+                            mode === "replace"
+                                ? `Replaced library with ${count} snippet${count === 1 ? "" : "s"}`
+                                : `Merged ${count} snippet${count === 1 ? "" : "s"}`,
+                        );
+                    },
+                }).open();
+            } catch (err) {
+                new Notice(
+                    `Import failed: ${err instanceof Error ? err.message : String(err)}`,
+                );
+            }
+        };
+        input.click();
+    }
+
+    private revealDataFile() {
+        try {
+            if (Platform.isDesktop) {
+                const adapter = this.app.vault.adapter as { getBasePath?: () => string };
+                if (typeof adapter.getBasePath !== "function") {
+                    throw new Error("Not supported on this platform");
+                }
+                const base: string = adapter.getBasePath();
+                const configDir: string = this.app.vault.configDir;
+                const path = `${base}/${configDir}/plugins/snipsidian/data.json`;
+                const electron = (
+                    window as {
+                        require?: (m: string) => {
+                            shell?: { showItemInFolder?: (p: string) => void };
+                        };
+                    }
+                ).require?.("electron");
+                if (!electron?.shell?.showItemInFolder) {
+                    throw new Error("Electron shell not available");
+                }
+                electron.shell.showItemInFolder(path);
+            } else {
+                new Notice("File manager access is only available on desktop");
+            }
+        } catch (err) {
+            new Notice(
+                `Failed to reveal file: ${err instanceof Error ? err.message : String(err)}`,
+            );
+        }
+    }
+
+    private openDemo() {
+        try {
+            const adapter = this.app.vault.adapter as { getBasePath?: () => string };
+            const base: string = adapter?.getBasePath?.() ?? "";
+            const configDir: string = this.app.vault.configDir;
+            const absPath = `${base}/${configDir}/plugins/snipsidian/docs/screens/espanso-demo.gif`;
+            window.open(absPath, "_blank", "noopener,noreferrer");
+        } catch (err) {
+            new Notice(
+                `Failed to open demo: ${err instanceof Error ? err.message : String(err)}`,
+            );
+        }
     }
 }

--- a/src/ui/components/Modals.ts
+++ b/src/ui/components/Modals.ts
@@ -1,6 +1,7 @@
 import { App, ButtonComponent, Modal, Setting, TextComponent } from "obsidian";
 import type SnipSidianPlugin from "../../main";
 import { DiffResult, displayGroupTitle, slugifyGroup } from "../../services/utils";
+import { computeImportDiff } from "../../services/import-diff";
 
 /** Simple JSON copy/paste modal */
 export class JSONModal extends Modal {
@@ -436,5 +437,186 @@ export class AddSnippetModal extends Modal {
 
         const cancel = footer.createEl("button", { text: "Cancel" });
         cancel.onclick = () => this.close();
+    }
+}
+
+/**
+ * Preview-before-write modal for JSON snippet import (B-038). Replaces
+ * the silent `settings.snippets = parsed` that previously wiped users'
+ * libraries with no recovery path.
+ *
+ * The user picks a mode (merge | replace) — the modal renders the diff
+ * for the active mode so they can see exactly what's about to change.
+ * Replace mode shows the `removed` list in red as the destructive-
+ * action affordance (designer Q5: no second-confirm dialog).
+ *
+ * The caller owns the write. The modal's `onConfirm` callback is
+ * passed the chosen mode and the original `incoming` payload — the
+ * caller merges or replaces according to its policy.
+ */
+export class ImportPreviewModal extends Modal {
+    private mode: "merge" | "replace" = "merge";
+
+    constructor(
+        app: App,
+        private readonly opts: {
+            current: Record<string, string>;
+            incoming: Record<string, string>;
+            onConfirm: (mode: "merge" | "replace") => void | Promise<void>;
+        },
+    ) {
+        super(app);
+    }
+
+    onOpen(): void {
+        const { contentEl, titleEl } = this;
+        titleEl.setText("Import snippets");
+        contentEl.addClass("snipsidian-modal");
+        contentEl.addClass("snipsidian-import-modal");
+
+        const diff = computeImportDiff(this.opts.current, this.opts.incoming);
+
+        // Mode picker — merge first because it's the safe default.
+        const modeRow = contentEl.createDiv({ cls: "snipsy-import-mode" });
+        modeRow.createEl("label", { cls: "snipsy-import-mode-option" }, (label) => {
+            const radio = label.createEl("input", {
+                type: "radio",
+                attr: { name: "snipsy-import-mode", value: "merge" },
+            });
+            radio.checked = true;
+            radio.addEventListener("change", () => {
+                if (radio.checked) {
+                    this.mode = "merge";
+                    this.refreshDiffList(listEl, diff);
+                    this.refreshSummary(summaryEl, diff);
+                    this.refreshApplyButton(applyBtn, diff);
+                }
+            });
+            label.createSpan({ text: "Merge" });
+            label.createSpan({
+                cls: "snipsy-import-mode-hint",
+                text: "Keep existing snippets, add new and overwrite conflicts.",
+            });
+        });
+        modeRow.createEl("label", { cls: "snipsy-import-mode-option" }, (label) => {
+            const radio = label.createEl("input", {
+                type: "radio",
+                attr: { name: "snipsy-import-mode", value: "replace" },
+            });
+            radio.addEventListener("change", () => {
+                if (radio.checked) {
+                    this.mode = "replace";
+                    this.refreshDiffList(listEl, diff);
+                    this.refreshSummary(summaryEl, diff);
+                    this.refreshApplyButton(applyBtn, diff);
+                }
+            });
+            label.createSpan({ text: "Replace all" });
+            label.createSpan({
+                cls: "snipsy-import-mode-hint snipsy-import-mode-hint-danger",
+                text:
+                    diff.removed.length > 0
+                        ? `Delete ${diff.removed.length} existing snippet${diff.removed.length === 1 ? "" : "s"}, then import.`
+                        : "Replace existing snippets with the import.",
+            });
+        });
+
+        const summaryEl = contentEl.createDiv({ cls: "snipsy-import-summary" });
+        this.refreshSummary(summaryEl, diff);
+
+        const listEl = contentEl.createDiv({ cls: "snipsy-import-list" });
+        this.refreshDiffList(listEl, diff);
+
+        const footer = contentEl.createDiv({ cls: "modal-button-container" });
+        const cancel = footer.createEl("button", { text: "Cancel" });
+        cancel.onclick = () => this.close();
+
+        const applyBtn = footer.createEl("button", { cls: "mod-cta" });
+        this.refreshApplyButton(applyBtn, diff);
+        applyBtn.onclick = () => {
+            const result = this.opts.onConfirm(this.mode);
+            if (result instanceof Promise) {
+                void result.catch((error) => {
+                    console.error("Error in import onConfirm callback:", error);
+                });
+            }
+            this.close();
+        };
+    }
+
+    private refreshSummary(
+        el: HTMLElement,
+        diff: ReturnType<typeof computeImportDiff>,
+    ) {
+        el.empty();
+        const parts: string[] = [];
+        if (diff.added.length) parts.push(`${diff.added.length} new`);
+        if (diff.conflicts.length) parts.push(`${diff.conflicts.length} updated`);
+        if (this.mode === "replace" && diff.removed.length) {
+            parts.push(`${diff.removed.length} removed`);
+        }
+        if (diff.unchangedCount) parts.push(`${diff.unchangedCount} unchanged`);
+
+        if (parts.length === 0) {
+            el.createSpan({ text: "Nothing will change." });
+            return;
+        }
+        el.createSpan({ text: parts.join(" · ") });
+    }
+
+    private refreshDiffList(
+        el: HTMLElement,
+        diff: ReturnType<typeof computeImportDiff>,
+    ) {
+        el.empty();
+
+        const MAX_ROWS = 50;
+        let rendered = 0;
+        const remaining: string[] = [];
+
+        const renderRow = (tag: "new" | "update" | "remove", key: string, value: string) => {
+            if (rendered >= MAX_ROWS) {
+                remaining.push(key);
+                return;
+            }
+            const row = el.createDiv({ cls: "snipsy-import-row" });
+            row.createSpan({
+                cls: `snipsy-import-tag snipsy-import-tag-${tag}`,
+                text: tag === "new" ? "NEW" : tag === "update" ? "UPDATE" : "REMOVE",
+            });
+            row.createSpan({ cls: "snipsy-import-key", text: key });
+            row.createSpan({ cls: "snipsy-import-value", text: value });
+            rendered++;
+        };
+
+        for (const a of diff.added) renderRow("new", a.key, a.value);
+        for (const c of diff.conflicts) renderRow("update", c.key, c.incoming);
+        if (this.mode === "replace") {
+            for (const r of diff.removed) renderRow("remove", r.key, r.value);
+        }
+
+        if (remaining.length > 0) {
+            el.createDiv({
+                cls: "snipsy-import-more",
+                text: `…and ${remaining.length} more`,
+            });
+        }
+    }
+
+    private refreshApplyButton(
+        btn: HTMLButtonElement,
+        diff: ReturnType<typeof computeImportDiff>,
+    ) {
+        if (this.mode === "replace") {
+            btn.textContent = `Replace all (${Object.keys(this.opts.incoming).length})`;
+            // Danger affordance: red CTA. Designer Q5 explicitly does NOT
+            // want a second-confirm dialog — the visual + the `removed`
+            // list in the diff is the affordance.
+            btn.addClass("mod-warning");
+        } else {
+            const willChange = diff.added.length + diff.conflicts.length;
+            btn.textContent = willChange === 0 ? "Apply" : `Apply merge (${willChange})`;
+            btn.removeClass("mod-warning");
+        }
     }
 }

--- a/styles.css
+++ b/styles.css
@@ -432,6 +432,94 @@
 .modal.snipsy-install .diff-tag.is-new      { background: rgba(108, 197, 133, 0.15); color: var(--snipsy-success); }
 .modal.snipsy-install .diff-tag.is-replace  { background: rgba(232, 113, 106, 0.14); color: var(--snipsy-danger); }
 
+/* ---- Import preview modal (B-038 fix) ----
+   Replaces the old silent-wipe import. Merge/replace picker + diff
+   list. Replace mode shows `removed` rows in red as the destructive-
+   action affordance (designer Q5 — no second-confirm dialog). */
+.snipsidian-import-modal .snipsy-import-mode {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+.snipsidian-import-modal .snipsy-import-mode-option {
+  display: grid;
+  grid-template-columns: auto auto 1fr;
+  align-items: baseline;
+  gap: 8px;
+  padding: 6px 10px;
+  border: 1px solid var(--snipsy-divider);
+  border-radius: var(--snipsy-radius);
+  cursor: pointer;
+}
+.snipsidian-import-modal .snipsy-import-mode-hint {
+  font-size: 12px;
+  color: var(--snipsy-text-muted);
+}
+.snipsidian-import-modal .snipsy-import-mode-hint-danger {
+  color: var(--snipsy-danger);
+}
+.snipsidian-import-modal .snipsy-import-summary {
+  font-size: 13px;
+  color: var(--snipsy-text-muted);
+  margin: 8px 0;
+}
+.snipsidian-import-modal .snipsy-import-list {
+  max-height: 320px;
+  overflow-y: auto;
+  border: 1px solid var(--snipsy-divider);
+  border-radius: var(--snipsy-radius);
+  margin-bottom: 12px;
+}
+.snipsidian-import-modal .snipsy-import-row {
+  display: grid;
+  grid-template-columns: 64px minmax(80px, 200px) 1fr;
+  gap: 10px;
+  padding: 6px 10px;
+  border-top: 1px solid var(--snipsy-divider);
+  font-size: 12.5px;
+}
+.snipsidian-import-modal .snipsy-import-row:first-child { border-top: 0; }
+.snipsidian-import-modal .snipsy-import-tag {
+  font-size: 10.5px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  padding: 2px 6px;
+  border-radius: 3px;
+  width: fit-content;
+}
+.snipsidian-import-modal .snipsy-import-tag-new {
+  background: rgba(108, 197, 133, 0.15);
+  color: var(--snipsy-success);
+}
+.snipsidian-import-modal .snipsy-import-tag-update {
+  background: rgba(108, 162, 232, 0.15);
+  color: var(--snipsy-accent);
+}
+.snipsidian-import-modal .snipsy-import-tag-remove {
+  background: rgba(232, 113, 106, 0.14);
+  color: var(--snipsy-danger);
+}
+.snipsidian-import-modal .snipsy-import-key {
+  font-family: var(--snipsy-mono);
+  font-weight: 500;
+}
+.snipsidian-import-modal .snipsy-import-value {
+  font-family: var(--snipsy-mono);
+  color: var(--snipsy-text-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.snipsidian-import-modal .snipsy-import-more {
+  padding: 8px 10px;
+  font-size: 12px;
+  color: var(--snipsy-text-faint);
+  text-align: center;
+  border-top: 1px solid var(--snipsy-divider);
+}
+
 /* ---- Reduced motion ---- */
 /* Honour the user's OS preference (B-089 / a11y A-011). Transitions
    and animations are subtle in Snipsy, but vestibular-disorder users


### PR DESCRIPTION
## Summary

Closes the silent-import-wipe bug (B-038) and strips 8 redundant CTAs from BasicTab. Adds `ImportPreviewModal` with merge/replace picker + diff list.

## Backlog items closed

- **B-038 / B-095** — Import JSON no longer wipes the library silently. It opens `ImportPreviewModal` showing the diff (added / updated / removed) and a merge|replace picker. Replace mode renders the `removed` list in red as the destructive-action affordance (designer Q5: no second-confirm dialog).
- **B-039** — Stripped `.setCta()` from 8 BasicTab buttons. None of them are primary actions; they read as equally-weighted utilities now.
- **B-091 (partial)** — Three `Setting().setHeading()` styled-divs → real `<h3>` (Commands / Backup / Help & Resources).
- Microcopy alignment with HANDOFF table: \"Export & Import\" → \"Backup\", \"Open GitHub\" → \"Open\", \"Browse packages\" → \"Open hub\".

## Notable changes

- `src/services/import-diff.ts` — new pure function `computeImportDiff(current, incoming)` returning `{ added, conflicts, removed, unchangedCount }`. Sorted by key for deterministic rendering. No DOM, no Obsidian — testable at contract level.
- `src/ui/components/Modals.ts` — new `ImportPreviewModal`. Owns the UX (mode picker + diff); the caller owns the write.
- `BasicTab.ts` rewritten — extracted handlers into named methods (\`exportJson\`, \`startImport\`, \`revealDataFile\`, \`openDemo\`, \`openHotkeyTab\`); kept platform/electron detection intact.

## Tests

10 boundary tests for `computeImportDiff` per [ADR-0005](.claude/brain/decisions/0005-test-philosophy.md):

- new keys → \`added\`
- same-value keys → \`unchangedCount\` (**not** \`conflicts\`)
- different-value keys → \`conflicts\` with both sides
- current-only keys → \`removed\` (**the load-bearing assertion** — without this list, replace-mode has no warning surface)
- empty-string values are real values, not absence
- deterministic ordering (alphabetical by key)
- empty-import = full delete; empty-current = fresh install
- no input mutation

- \`npm test\` — 259/259 pass
- Coverage — above thresholds
- \`npm run lint\` — clean
- \`npx tsc --noEmit\` — clean
- \`npm run build\` — 185.1kb (+3.4kb for modal + diff)

## Test plan

- [ ] General tab: 8 buttons, none look like primary CTAs
- [ ] Click Import JSON → pick a file with both new and overlapping keys → modal shows summary line + new/update rows
- [ ] Switch to \"Replace all\" → removed rows appear in red, summary updates, Apply button turns into red \"Replace all (N)\"
- [ ] Switch back to Merge → removed rows disappear; Apply button reads \"Apply merge (N)\"
- [ ] Apply merge → existing snippets kept, new ones added, conflicts overwritten with incoming
- [ ] Apply replace → library is exactly the incoming set
- [ ] Cancel → no write happens
- [ ] H3s are screen-reader-visible (try with VoiceOver / NVDA: \"heading level 3, Commands\")

Refs: ADR-0006 sub-PR 4e, HANDOFF.md §2c + designer Q5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)