### PR TITLE
refactor(ui): align General tab visual style with About tab

### DIFF
--- a/src/ui/components/BasicTab.ts
+++ b/src/ui/components/BasicTab.ts
@@ -1,16 +1,19 @@
-import { App, Notice, Platform, Setting } from "obsidian";
+import { App, Notice, Platform } from "obsidian";
 import type SnipSidianPlugin from "../../main";
 import { isRecordOfString } from "../../shared/guards";
 import { ImportPreviewModal } from "./Modals";
 
 /**
- * General tab. Per the 1.1.0 redesign (HANDOFF §2c) every button here
- * is a utility, not a primary action — so none get `.setCta()`. The
- * old "8 CTAs in one tab" pattern made primary actions unreadable.
+ * General tab. Visually aligned with the About tab: one section
+ * heading at the top, then UPPERCASE-style subheadings (`<h4>`) and
+ * bordered-list cards for each group. Help & Resources is gone —
+ * it overlapped with the About tab, which is the canonical home for
+ * documentation / community links.
  *
- * Import flow no longer wipes the library silently (B-038). It now
- * opens `ImportPreviewModal` with the parsed payload; the user picks
- * merge vs replace and sees the diff before the write happens.
+ * All actions here are equally-weighted utilities, so no buttons
+ * carry `.setCta()` (HANDOFF §2c). Import flow opens
+ * `ImportPreviewModal` so the user can preview merge vs replace
+ * before the write (B-038).
  */
 export class BasicTab {
     constructor(
@@ -19,102 +22,73 @@ export class BasicTab {
     ) {}
 
     render(root: HTMLElement) {
-        // Real <h3>s per accessibility audit B-091. `Setting().setHeading()`
-        // emits a styled-div that screen readers don't pick up as a
-        // section heading.
-        const sectionHeading = (parent: HTMLElement, title: string, hint?: string) => {
-            parent.createEl("h3", { text: title, cls: "snipsy-tab-heading" });
-            if (hint) parent.createEl("p", { text: hint, cls: "snipsy-hint" });
-        };
+        root.empty();
+        root.createEl("h3", { text: "Snipsy settings", cls: "snipsy-tab-heading" });
 
         // ---- Commands ----
-        sectionHeading(root, "Commands", "Configure hotkeys for Snipsy commands.");
+        root.createEl("h4", { text: "Commands", cls: "snipsy-tab-subheading" });
+        const commands = root.createDiv({ cls: "snipsy-about-list" });
 
-        new Setting(root)
-            .setName("Insert snippet")
-            .setDesc("Open the snippet picker to insert snippets")
-            .addButton((btn) =>
-                btn.setButtonText("Set hotkey").onClick(() => {
-                    this.openHotkeyTab("snipsidian:insert-snippet");
-                }),
-            );
+        this.renderRow(commands, {
+            title: "Insert snippet",
+            description: "Open the snippet picker.",
+            buttonText: "Set hotkey",
+            onClick: () => this.openHotkeyTab("snipsidian:insert-snippet"),
+        });
 
-        new Setting(root)
-            .setName("Open settings")
-            .setDesc("Quick access to plugin settings")
-            .addButton((btn) =>
-                btn.setButtonText("Set hotkey").onClick(() => {
-                    this.openHotkeyTab("snipsidian:open-settings");
-                }),
-            );
+        this.renderRow(commands, {
+            title: "Open settings",
+            description: "Jump straight to Snipsy settings.",
+            buttonText: "Set hotkey",
+            onClick: () => this.openHotkeyTab("snipsidian:open-settings"),
+        });
 
-        // ---- Backup (export + import + reveal) ----
-        sectionHeading(
-            root,
-            "Backup",
-            "Export your snippets, restore from a backup, or open the data file.",
-        );
+        // ---- Backup ----
+        root.createEl("h4", { text: "Backup", cls: "snipsy-tab-subheading" });
+        const backup = root.createDiv({ cls: "snipsy-about-list" });
 
-        new Setting(root)
-            .setName("Export snippets")
-            .setDesc("Download your snippets as a JSON file")
-            .addButton((btn) =>
-                btn.setButtonText("Export JSON").onClick(() => this.exportJson()),
-            );
+        this.renderRow(backup, {
+            title: "Export snippets",
+            description: "Download your library as JSON.",
+            buttonText: "Export JSON",
+            onClick: () => this.exportJson(),
+        });
 
-        new Setting(root)
-            .setName("Import snippets")
-            .setDesc("Preview a JSON file before merging or replacing your library")
-            .addButton((btn) =>
-                btn.setButtonText("Import JSON").onClick(() => this.startImport()),
-            );
+        this.renderRow(backup, {
+            title: "Import snippets",
+            description: "Preview a JSON file before merge or replace.",
+            buttonText: "Import JSON",
+            onClick: () => this.startImport(),
+        });
 
-        new Setting(root)
-            .setName("Reveal data file")
-            .setDesc("Open the snippets data file in your file manager")
-            .addButton((btn) =>
-                btn.setButtonText("Reveal").onClick(() => this.revealDataFile()),
-            );
+        this.renderRow(backup, {
+            title: "Reveal data file",
+            description: "Open the data file in your file manager.",
+            buttonText: "Reveal",
+            onClick: () => this.revealDataFile(),
+        });
+    }
 
-        // ---- Help & Resources ----
-        sectionHeading(
-            root,
-            "Help & Resources",
-            "Documentation, demos, and external snippet catalogs.",
-        );
+    private renderRow(
+        parent: HTMLElement,
+        opts: {
+            title: string;
+            description: string;
+            buttonText: string;
+            onClick: () => void;
+        },
+    ) {
+        const row = parent.createDiv({ cls: "snipsy-about-row" });
+        const text = row.createDiv({ cls: "snipsy-about-text" });
+        text.createDiv({ cls: "snipsy-about-row-title", text: opts.title });
+        text.createDiv({ cls: "snipsy-about-row-desc", text: opts.description });
 
-        new Setting(root)
-            .setName("Documentation")
-            .setDesc("GitHub repository — docs, examples, and source")
-            .addButton((btn) =>
-                btn.setButtonText("Open").onClick(() => {
-                    window.open(
-                        "https://github.com/Dimagious/snipsidian",
-                        "_blank",
-                        "noopener,noreferrer",
-                    );
-                }),
-            );
-
-        new Setting(root)
-            .setName("Espanso hub")
-            .setDesc("Thousands of community-created packages")
-            .addButton((btn) =>
-                btn.setButtonText("Open hub").onClick(() => {
-                    window.open(
-                        "https://hub.espanso.org/",
-                        "_blank",
-                        "noopener,noreferrer",
-                    );
-                }),
-            );
-
-        new Setting(root)
-            .setName("Demo")
-            .setDesc("See the plugin in action")
-            .addButton((btn) =>
-                btn.setButtonText("View demo").onClick(() => this.openDemo()),
-            );
+        const btn = row.createEl("button", {
+            cls: "snipsy-about-row-action",
+            text: opts.buttonText,
+            attr: { type: "button", "aria-label": `${opts.buttonText}: ${opts.title}` },
+        });
+        btn.addEventListener("click", opts.onClick);
     }
 
     private openHotkeyTab(commandId: string) {
@@ -163,7 +137,6 @@ export class BasicTab {
                     current: this.plugin.settings.snippets,
                     incoming: parsed,
                     onConfirm: async (mode) => {
-                        // Caller owns the write per modal contract.
                         this.plugin.settings.snippets =
                             mode === "replace"
                                 ? parsed
@@ -213,20 +186,6 @@ export class BasicTab {
         } catch (err) {
             new Notice(
                 `Failed to reveal file: ${err instanceof Error ? err.message : String(err)}`,
-            );
-        }
-    }
-
-    private openDemo() {
-        try {
-            const adapter = this.app.vault.adapter as { getBasePath?: () => string };
-            const base: string = adapter?.getBasePath?.() ?? "";
-            const configDir: string = this.app.vault.configDir;
-            const absPath = `${base}/${configDir}/plugins/snipsidian/docs/screens/espanso-demo.gif`;
-            window.open(absPath, "_blank", "noopener,noreferrer");
-        } catch (err) {
-            new Notice(
-                `Failed to open demo: ${err instanceof Error ? err.message : String(err)}`,
             );
         }
     }


### PR DESCRIPTION
## Summary

Tiny polish PR — the General-tab refactor commit got lost during the PR #25 merge (squashed before the push landed). Cherry-picked back onto its own branch.

After smoke-testing the 1.1.0 epic the General tab read as inconsistent with the rest of the redesign: three large h3s + flat \`Setting()\` rows, while every other tab uses one heading + uppercase subheadings + bordered-list cards.

- One top h3 \"Snipsy settings\"
- UPPERCASE \`<h4>\` subheadings (COMMANDS / BACKUP) reusing the existing \`.snipsy-tab-subheading\` class
- Bordered-list cards via \`.snipsy-about-list\` / \`.snipsy-about-row\` — same DOM as About so the two tabs read as parallel
- Dropped the Help & Resources section entirely (Documentation / Espanso hub / Demo all duplicated About tab links)
- Tightened row descriptions to one short clause each

Net: 8 rows in 3 groups → 5 rows in 2 groups. Behaviour identical aside from the deleted Help & Resources links (their About-tab twins remain).

- \`npm test\` — 232/232 pass
- Lint + tsc clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)