### PR TITLE
chore: clear scorecard warnings (CSS !important + type assertions)

### DIFF
--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -16,17 +16,23 @@
 @import './variables.css';
 
 /* ---- Reset green-card era leftovers (older settings markup) ---- */
-.snipsidian-settings .snipsy-section,
-.snipsidian-settings .snipsy-subsection,
-.snipsidian-settings .snipsy-snippet-manager,
-.snipsidian-settings .snipsy-commands-section,
-.snipsidian-settings .snipsy-export-section,
-.snipsidian-settings .snipsy-help-section,
-.snipsidian-settings .snipsy-community-browse-section {
-  border: 0 !important;
-  background: transparent !important;
-  padding: 0 !important;
-  margin: 0 !important;
+/* `.snipsidian-settings.snipsidian-settings` is class-doubled to
+ * raise specificity above any Obsidian-side `.setting-item` defaults
+ * without falling back to `!important` (Obsidian scorecard rule
+ * `declaration-no-important`). The earlier `!important` here landed
+ * during the 1.1.0 CSS rewrite; specificity is the cleaner tool when
+ * we control both sides of the cascade. */
+.snipsidian-settings.snipsidian-settings .snipsy-section,
+.snipsidian-settings.snipsidian-settings .snipsy-subsection,
+.snipsidian-settings.snipsidian-settings .snipsy-snippet-manager,
+.snipsidian-settings.snipsidian-settings .snipsy-commands-section,
+.snipsidian-settings.snipsidian-settings .snipsy-export-section,
+.snipsidian-settings.snipsidian-settings .snipsy-help-section,
+.snipsidian-settings.snipsidian-settings .snipsy-community-browse-section {
+  border: 0;
+  background: transparent;
+  padding: 0;
+  margin: 0;
 }
 
 /* ---- Tabs (top of settings pane) ---- */
@@ -77,9 +83,10 @@
 
 /* Utility — used by tab JS to hide/show without setting inline
    styles (Obsidian's `no-static-styles-assignment` lint rule forbids
-   `el.style.display = "none"`). Keep this near the top so anything can
-   use it. */
-.snipsidian-settings .is-hidden { display: none !important; }
+   `el.style.display = "none"`). Class-doubled selector raises
+   specificity (0,2,0 → 0,3,0) so we don't need `!important` to beat
+   sibling rules. Keep near the top so anything can use it. */
+.snipsidian-settings.snipsidian-settings .is-hidden.is-hidden { display: none; }
 
 /* ---- Snippets-tab heading ---- */
 /* Real <h3> per accessibility audit (B-091) — `Setting().setHeading()`

--- a/src/test/dom-polyfill.ts
+++ b/src/test/dom-polyfill.ts
@@ -58,7 +58,7 @@ function createElImpl(
     opts?: DomElementInfo | string,
     cb?: (el: HTMLElement) => void,
 ): HTMLElement {
-    const doc = this instanceof Document ? this : this.ownerDocument!;
+    const doc = this instanceof Document ? this : this.ownerDocument;
     const el = doc.createElement(tag);
     applyOptions(el, opts);
     if (this instanceof HTMLElement) this.appendChild(el);

--- a/src/ui/utils/ui-state.ts
+++ b/src/ui/utils/ui-state.ts
@@ -91,7 +91,7 @@ export class UIStateManager {
 
     loadActiveTab(): TabId {
         this.ensureUiState();
-        const raw = this.settings.ui!.activeTab as string | undefined;
+        const raw = this.settings.ui!.activeTab;
 
         // New-ID happy path.
         if (raw && VALID_TAB_IDS.has(raw as TabId)) return raw as TabId;

--- a/styles.css
+++ b/styles.css
@@ -59,17 +59,23 @@
 
 
 /* ---- Reset green-card era leftovers (older settings markup) ---- */
-.snipsidian-settings .snipsy-section,
-.snipsidian-settings .snipsy-subsection,
-.snipsidian-settings .snipsy-snippet-manager,
-.snipsidian-settings .snipsy-commands-section,
-.snipsidian-settings .snipsy-export-section,
-.snipsidian-settings .snipsy-help-section,
-.snipsidian-settings .snipsy-community-browse-section {
-  border: 0 !important;
-  background: transparent !important;
-  padding: 0 !important;
-  margin: 0 !important;
+/* `.snipsidian-settings.snipsidian-settings` is class-doubled to
+ * raise specificity above any Obsidian-side `.setting-item` defaults
+ * without falling back to `!important` (Obsidian scorecard rule
+ * `declaration-no-important`). The earlier `!important` here landed
+ * during the 1.1.0 CSS rewrite; specificity is the cleaner tool when
+ * we control both sides of the cascade. */
+.snipsidian-settings.snipsidian-settings .snipsy-section,
+.snipsidian-settings.snipsidian-settings .snipsy-subsection,
+.snipsidian-settings.snipsidian-settings .snipsy-snippet-manager,
+.snipsidian-settings.snipsidian-settings .snipsy-commands-section,
+.snipsidian-settings.snipsidian-settings .snipsy-export-section,
+.snipsidian-settings.snipsidian-settings .snipsy-help-section,
+.snipsidian-settings.snipsidian-settings .snipsy-community-browse-section {
+  border: 0;
+  background: transparent;
+  padding: 0;
+  margin: 0;
 }
 
 /* ---- Tabs (top of settings pane) ---- */
@@ -120,9 +126,10 @@
 
 /* Utility — used by tab JS to hide/show without setting inline
    styles (Obsidian's `no-static-styles-assignment` lint rule forbids
-   `el.style.display = "none"`). Keep this near the top so anything can
-   use it. */
-.snipsidian-settings .is-hidden { display: none !important; }
+   `el.style.display = "none"`). Class-doubled selector raises
+   specificity (0,2,0 → 0,3,0) so we don't need `!important` to beat
+   sibling rules. Keep near the top so anything can use it. */
+.snipsidian-settings.snipsidian-settings .is-hidden.is-hidden { display: none; }
 
 /* ---- Snippets-tab heading ---- */
 /* Real <h3> per accessibility audit (B-091) — `Setting().setHeading()`


### PR DESCRIPTION
## Summary

Clears the 15 Review warnings currently flagged by the Obsidian community plugin scorecard at [community.obsidian.md/plugins/snipsidian](https://community.obsidian.md/plugins/snipsidian):

- **14× `declaration-no-important`** — 7 `!important` keywords in `styles.css` (scanner counts per-property-per-selector). Reduced to 2 (only the irreducible `prefers-reduced-motion` overrides remain — idiomatic per MDN).
- **1× `@typescript-eslint/no-unnecessary-type-assertion`** — redundant `as string | undefined` on a value already typed that way in `src/ui/utils/ui-state.ts:94`.

CSS approach mirrors the 1.0.6 cleanup: class-doubled specificity (`.snipsidian-settings.snipsidian-settings .snipsy-section`) gives the same override strength without the keyword.

Bonus TS hygiene: dropped a redundant `!` non-null assertion in `src/test/dom-polyfill.ts:61` (doesn't reach the scorecard since `src/test/**` doesn't bundle, but flagged by lint once B-114 un-exempts the path).

This is the chore PR that precedes the `1.1.2` release commit — per [release-bump SKILL.md](.claude/release-bump/SKILL.md), a chore-only release still bumps PATCH so the Obsidian community plugin index ships the scorecard-clean bundle to users.

## Test plan

- [x] `npm test` — 320 / 320 passing
- [x] `npm run build:css` — `styles.css` rebuilt; `grep -c '!important' styles.css` drops from 7 → 2
- [x] `npx eslint --rule '@typescript-eslint/no-unnecessary-type-assertion: error'` — 0 warnings
- [ ] Visual regression: verify settings tabs / picker modal / package browser still render correctly after specificity bump (manual smoke in a test vault)

🤖 Generated with [Claude Code](https://claude.com/claude-code)