### PR TITLE
feat: SnippetPickerModal CSS (B-115) + DRY normalizeTrigger + honest README video copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@
 
 > **Type `todo` and a space, get `- [ ]`.** Snipsy is the actively-maintained hotstring plugin for Obsidian — markdown-aware, with a community catalog and Espanso import. No scripting required.
 
-[![Snipsy demo](docs/screens/demo.gif)](docs/screens/demo.mp4)
+![Snipsy demo](docs/screens/demo.gif)
 
-> 🔊 [Watch the 60-second walkthrough with voice-over](docs/screens/demo.mp4) — GitHub can't autoplay narrated video inline, so the GIF above is silent; click through for the MP4.
+> Silent GIF above. A 60-second narrated MP4 lives at [`docs/screens/demo.mp4`](docs/screens/demo.mp4) — GitHub serves it as a download, so save it locally or watch in your editor.
 
 ---
 

--- a/src/packages/espanso.ts
+++ b/src/packages/espanso.ts
@@ -1,6 +1,7 @@
 // Lightweight converter from Espanso YAML to { trigger: replacement }
 import * as YAML from "yaml";
 import type { EspansoDocument } from "../services/package-types";
+import { normalizeTrigger } from "../services/utils";
 
 /**
  * Supported Espanso fields:
@@ -8,7 +9,10 @@ import type { EspansoDocument } from "../services/package-types";
  *     - trigger: ":brb"        // or 'triggers: [":brb", ":omw"]'
  *       replace: "be right back"
  *
- * We ignore complex placeholders/conditions. Leading ":" in triggers is removed.
+ * We ignore complex placeholders/conditions. Trigger normalisation
+ * (leading/trailing colon strip + whitespace trim) lives in the
+ * shared `services/utils.ts:normalizeTrigger` so both this importer
+ * and the community-packages install path apply the same rules.
  */
 export function espansoYamlToSnippets(text: string): Record<string, string> {
     const doc = YAML.parse(text) as EspansoDocument;
@@ -43,11 +47,3 @@ export function espansoYamlToSnippets(text: string): Record<string, string> {
     return out;
 }
 
-function normalizeTrigger(t: string): string {
-    // Espanso often uses ":" prefix; our expander thinks ":" is a separator.
-    // Trim whitespace first so leading-space-then-colon (`"  :brb "`) still
-    // strips the colon — otherwise the colon would leak through and the
-    // trigger would be unreachable (":" is a separator, no engine path
-    // would ever match it).
-    return t.trim().replace(/^:+/, "");
-}

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -753,6 +753,224 @@
   line-height: 1.4;
 }
 
+/* ============================================================
+   SnippetPickerModal (B-115)
+
+   The Insert-snippet / Wrap-selection modal (`Cmd+P → Insert
+   snippet`). 1.1.x shipped the DOM (search input, results listbox,
+   preview pane, hints row) but no CSS, so the picker rendered as a
+   plain vertical text dump — each row stacked the trigger, group
+   label, and preview as three separate lines with no layout. This
+   block puts in the grid layout, hover/selected states, and the
+   highlight markers for `$|` / `$1`-`$9`.
+
+   Modal's contentEl carries `.snippet-picker-modal` (set in
+   `onOpen`), separate from `.snipsidian-settings` and from the
+   general `.snipsidian-modal` package-details modal.
+   ============================================================ */
+
+.snippet-picker-modal {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  min-width: 520px;
+  max-width: 800px;
+}
+
+/* Search label — small all-caps eyebrow above the input */
+.snippet-picker-modal > label[for="snipsy-picker-search"] {
+  font-size: 10.5px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--text-faint);
+  margin-bottom: -4px;
+}
+
+.snippet-picker-modal .search-input {
+  width: 100%;
+  padding: 9px 12px;
+  font-size: 14px;
+  border: 1px solid var(--background-modifier-border);
+  border-radius: 6px;
+  background: var(--background-secondary);
+  color: var(--text-normal);
+  outline: none;
+  transition: border-color 0.12s ease, box-shadow 0.12s ease;
+}
+.snippet-picker-modal .search-input:focus {
+  border-color: var(--interactive-accent);
+  box-shadow: 0 0 0 2px var(--interactive-accent-translucent, rgba(125,103,255,0.22));
+}
+
+/* Results listbox — scrollable, bordered. The .snipsy-picker-count
+   selector already exists above (line 389); we leave it untouched. */
+.snippet-picker-modal .snippet-results {
+  display: flex;
+  flex-direction: column;
+  max-height: 280px;
+  overflow-y: auto;
+  border: 1px solid var(--background-modifier-border);
+  border-radius: 6px;
+  background: var(--background-primary);
+}
+
+.snippet-picker-modal .snippet-results .empty-state {
+  padding: 24px 16px;
+  text-align: center;
+  color: var(--text-faint);
+  font-size: 13px;
+  font-style: italic;
+}
+
+/* Result row — grid: trigger | group-badge | mini-preview */
+.snippet-picker-modal .snippet-item {
+  display: grid;
+  grid-template-columns: minmax(80px, 160px) auto 1fr;
+  align-items: center;
+  gap: 12px;
+  padding: 7px 14px;
+  cursor: pointer;
+  border-bottom: 1px solid var(--background-modifier-border-hover, var(--background-modifier-border));
+}
+.snippet-picker-modal .snippet-item:last-child {
+  border-bottom: none;
+}
+.snippet-picker-modal .snippet-item:hover {
+  background: var(--background-modifier-hover);
+}
+.snippet-picker-modal .snippet-item.selected {
+  background: var(--interactive-accent-translucent, var(--background-modifier-active-hover));
+}
+.snippet-picker-modal .snippet-item.selected .snippet-name span {
+  color: var(--text-on-accent, var(--text-normal));
+}
+
+.snippet-picker-modal .snippet-name span {
+  font-family: var(--font-monospace);
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-normal);
+}
+
+.snippet-picker-modal .snippet-folder span {
+  display: inline-block;
+  padding: 1px 8px;
+  border-radius: 999px;
+  background: var(--background-secondary);
+  border: 1px solid var(--background-modifier-border);
+  color: var(--text-faint);
+  font-size: 10.5px;
+  line-height: 1.5;
+  letter-spacing: 0.2px;
+}
+
+.snippet-picker-modal .snippet-preview-text span {
+  font-family: var(--font-monospace);
+  font-size: 12px;
+  color: var(--text-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: block;
+}
+
+/* Preview heading — small all-caps eyebrow */
+.snippet-picker-modal .preview-label {
+  font-size: 10.5px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--text-faint);
+  margin: 6px 0 -4px;
+}
+
+/* Preview card */
+.snippet-picker-modal .snippet-preview {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 12px 14px;
+  border: 1px solid var(--background-modifier-border);
+  border-radius: 6px;
+  background: var(--background-secondary-alt, var(--background-secondary));
+  min-height: 64px;
+}
+
+.snippet-picker-modal .snippet-preview-meta {
+  font-size: 11.5px;
+  color: var(--text-faint);
+  line-height: 1.5;
+}
+.snippet-picker-modal .snippet-preview-meta strong {
+  color: var(--text-muted);
+  font-weight: 600;
+}
+
+.snippet-picker-modal .snippet-preview-text-container {
+  font-family: var(--font-monospace);
+  font-size: 12.5px;
+  color: var(--text-normal);
+  white-space: pre-wrap;
+  word-break: break-word;
+  line-height: 1.5;
+  max-height: 200px;
+  overflow-y: auto;
+}
+
+/* Cursor marker (`$|`) — accent-colored pill so users see at a
+   glance where the cursor lands after expansion. */
+.snippet-picker-modal .snippet-highlight-cursor {
+  display: inline-block;
+  padding: 0 4px;
+  border-radius: 3px;
+  background: var(--interactive-accent-translucent, rgba(125,103,255,0.18));
+  color: var(--interactive-accent);
+  font-weight: 600;
+  font-family: var(--font-monospace);
+}
+
+/* Tabstop markers (`$1`, `$2`, ...) — muted pill, less visually loud
+   than the cursor marker since tabstops in expansion mode are
+   literal placeholders the user overwrites manually. */
+.snippet-picker-modal .snippet-highlight-tabstop {
+  display: inline-block;
+  padding: 0 4px;
+  border-radius: 3px;
+  background: var(--background-modifier-border);
+  color: var(--text-muted);
+  font-family: var(--font-monospace);
+}
+
+.snippet-picker-modal .snippet-preview-empty {
+  color: var(--text-faint);
+  font-style: italic;
+  font-size: 12.5px;
+  text-align: center;
+  padding: 16px 0;
+}
+
+/* Hints row — kbd-style chips for Navigation / Enter / Esc / Click */
+.snippet-picker-modal .snippet-hints {
+  font-size: 11.5px;
+  color: var(--text-faint);
+  line-height: 2;
+  padding-top: 6px;
+  border-top: 1px solid var(--background-modifier-border);
+}
+.snippet-picker-modal .snippet-hints strong {
+  display: inline-block;
+  padding: 1px 6px;
+  margin: 0 2px;
+  border-radius: 4px;
+  background: var(--background-secondary);
+  border: 1px solid var(--background-modifier-border);
+  color: var(--text-muted);
+  font-size: 10.5px;
+  font-weight: 600;
+  font-family: var(--font-monospace);
+}
+
 /* ---- Reduced motion ---- */
 /* Honour the user's OS preference (B-089 / a11y A-011). Transitions
    and animations are subtle in Snipsy, but vestibular-disorder users

--- a/styles.css
+++ b/styles.css
@@ -796,6 +796,224 @@
   line-height: 1.4;
 }
 
+/* ============================================================
+   SnippetPickerModal (B-115)
+
+   The Insert-snippet / Wrap-selection modal (`Cmd+P → Insert
+   snippet`). 1.1.x shipped the DOM (search input, results listbox,
+   preview pane, hints row) but no CSS, so the picker rendered as a
+   plain vertical text dump — each row stacked the trigger, group
+   label, and preview as three separate lines with no layout. This
+   block puts in the grid layout, hover/selected states, and the
+   highlight markers for `$|` / `$1`-`$9`.
+
+   Modal's contentEl carries `.snippet-picker-modal` (set in
+   `onOpen`), separate from `.snipsidian-settings` and from the
+   general `.snipsidian-modal` package-details modal.
+   ============================================================ */
+
+.snippet-picker-modal {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  min-width: 520px;
+  max-width: 800px;
+}
+
+/* Search label — small all-caps eyebrow above the input */
+.snippet-picker-modal > label[for="snipsy-picker-search"] {
+  font-size: 10.5px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--text-faint);
+  margin-bottom: -4px;
+}
+
+.snippet-picker-modal .search-input {
+  width: 100%;
+  padding: 9px 12px;
+  font-size: 14px;
+  border: 1px solid var(--background-modifier-border);
+  border-radius: 6px;
+  background: var(--background-secondary);
+  color: var(--text-normal);
+  outline: none;
+  transition: border-color 0.12s ease, box-shadow 0.12s ease;
+}
+.snippet-picker-modal .search-input:focus {
+  border-color: var(--interactive-accent);
+  box-shadow: 0 0 0 2px var(--interactive-accent-translucent, rgba(125,103,255,0.22));
+}
+
+/* Results listbox — scrollable, bordered. The .snipsy-picker-count
+   selector already exists above (line 389); we leave it untouched. */
+.snippet-picker-modal .snippet-results {
+  display: flex;
+  flex-direction: column;
+  max-height: 280px;
+  overflow-y: auto;
+  border: 1px solid var(--background-modifier-border);
+  border-radius: 6px;
+  background: var(--background-primary);
+}
+
+.snippet-picker-modal .snippet-results .empty-state {
+  padding: 24px 16px;
+  text-align: center;
+  color: var(--text-faint);
+  font-size: 13px;
+  font-style: italic;
+}
+
+/* Result row — grid: trigger | group-badge | mini-preview */
+.snippet-picker-modal .snippet-item {
+  display: grid;
+  grid-template-columns: minmax(80px, 160px) auto 1fr;
+  align-items: center;
+  gap: 12px;
+  padding: 7px 14px;
+  cursor: pointer;
+  border-bottom: 1px solid var(--background-modifier-border-hover, var(--background-modifier-border));
+}
+.snippet-picker-modal .snippet-item:last-child {
+  border-bottom: none;
+}
+.snippet-picker-modal .snippet-item:hover {
+  background: var(--background-modifier-hover);
+}
+.snippet-picker-modal .snippet-item.selected {
+  background: var(--interactive-accent-translucent, var(--background-modifier-active-hover));
+}
+.snippet-picker-modal .snippet-item.selected .snippet-name span {
+  color: var(--text-on-accent, var(--text-normal));
+}
+
+.snippet-picker-modal .snippet-name span {
+  font-family: var(--font-monospace);
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text-normal);
+}
+
+.snippet-picker-modal .snippet-folder span {
+  display: inline-block;
+  padding: 1px 8px;
+  border-radius: 999px;
+  background: var(--background-secondary);
+  border: 1px solid var(--background-modifier-border);
+  color: var(--text-faint);
+  font-size: 10.5px;
+  line-height: 1.5;
+  letter-spacing: 0.2px;
+}
+
+.snippet-picker-modal .snippet-preview-text span {
+  font-family: var(--font-monospace);
+  font-size: 12px;
+  color: var(--text-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: block;
+}
+
+/* Preview heading — small all-caps eyebrow */
+.snippet-picker-modal .preview-label {
+  font-size: 10.5px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--text-faint);
+  margin: 6px 0 -4px;
+}
+
+/* Preview card */
+.snippet-picker-modal .snippet-preview {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 12px 14px;
+  border: 1px solid var(--background-modifier-border);
+  border-radius: 6px;
+  background: var(--background-secondary-alt, var(--background-secondary));
+  min-height: 64px;
+}
+
+.snippet-picker-modal .snippet-preview-meta {
+  font-size: 11.5px;
+  color: var(--text-faint);
+  line-height: 1.5;
+}
+.snippet-picker-modal .snippet-preview-meta strong {
+  color: var(--text-muted);
+  font-weight: 600;
+}
+
+.snippet-picker-modal .snippet-preview-text-container {
+  font-family: var(--font-monospace);
+  font-size: 12.5px;
+  color: var(--text-normal);
+  white-space: pre-wrap;
+  word-break: break-word;
+  line-height: 1.5;
+  max-height: 200px;
+  overflow-y: auto;
+}
+
+/* Cursor marker (`$|`) — accent-colored pill so users see at a
+   glance where the cursor lands after expansion. */
+.snippet-picker-modal .snippet-highlight-cursor {
+  display: inline-block;
+  padding: 0 4px;
+  border-radius: 3px;
+  background: var(--interactive-accent-translucent, rgba(125,103,255,0.18));
+  color: var(--interactive-accent);
+  font-weight: 600;
+  font-family: var(--font-monospace);
+}
+
+/* Tabstop markers (`$1`, `$2`, ...) — muted pill, less visually loud
+   than the cursor marker since tabstops in expansion mode are
+   literal placeholders the user overwrites manually. */
+.snippet-picker-modal .snippet-highlight-tabstop {
+  display: inline-block;
+  padding: 0 4px;
+  border-radius: 3px;
+  background: var(--background-modifier-border);
+  color: var(--text-muted);
+  font-family: var(--font-monospace);
+}
+
+.snippet-picker-modal .snippet-preview-empty {
+  color: var(--text-faint);
+  font-style: italic;
+  font-size: 12.5px;
+  text-align: center;
+  padding: 16px 0;
+}
+
+/* Hints row — kbd-style chips for Navigation / Enter / Esc / Click */
+.snippet-picker-modal .snippet-hints {
+  font-size: 11.5px;
+  color: var(--text-faint);
+  line-height: 2;
+  padding-top: 6px;
+  border-top: 1px solid var(--background-modifier-border);
+}
+.snippet-picker-modal .snippet-hints strong {
+  display: inline-block;
+  padding: 1px 6px;
+  margin: 0 2px;
+  border-radius: 4px;
+  background: var(--background-secondary);
+  border: 1px solid var(--background-modifier-border);
+  color: var(--text-muted);
+  font-size: 10.5px;
+  font-weight: 600;
+  font-family: var(--font-monospace);
+}
+
 /* ---- Reduced motion ---- */
 /* Honour the user's OS preference (B-089 / a11y A-011). Transitions
    and animations are subtle in Snipsy, but vestibular-disorder users


### PR DESCRIPTION
## Summary

Three concerns bundled — one fixes a visible UX gap, one removes a shipped lie, one tidies an unnecessary duplication. All three are pure-additive: no behavioural regressions, no API churn.

## 1. B-115 — write the missing picker CSS

`SnippetPickerModal` (Cmd+P → Insert snippet) had been shipping with zero styles since 1.1.0. The DOM emitted a dozen classes (`.snippet-results`, `.snippet-item`, `.snippet-name`, `.snippet-folder`, `.snippet-preview-text`, `.snippet-preview`, `.snippet-preview-meta`, `.snippet-preview-text-container`, `.snippet-highlight-cursor`, `.snippet-highlight-tabstop`, `.empty-state`, `.snippet-hints`), and `main.css` had rules for **zero of them**. Result: the picker rendered as a vertical text dump — trigger / (group) / preview as three stacked lines per row, preview pane indistinguishable from regular text, no focus ring on search.

Added a dedicated `.snippet-picker-modal` block (~210 lines) covering:

- Search input with focus ring in accent colour
- Results listbox: scrollable bordered card, `max-height: 280px`
- Each row: 3-col grid `[trigger][group-pill][mini-preview]` with hover + selected states
- Preview card below: bordered, monospace, `white-space: pre-wrap` so multi-line replacements (callouts, tables, journal templates) render correctly
- **`$|` cursor marker**: accent-coloured inline pill so users see at a glance where the cursor will land after expansion
- **`$1` / `$2` / `$N` tabstop markers**: muted inline pill (less visually loud — they're literal placeholders the user overwrites manually in expansion mode, not real CM6 tabstops)
- Hints row: kbd-style chips for Navigation / Enter / Esc / Click

Everything uses Obsidian CSS custom properties (`--text-muted`, `--background-modifier-border`, `--interactive-accent-translucent`, etc.) so the modal automatically follows the user's theme.

## 2. DRY — `espanso.ts` now imports the shared `normalizeTrigger`

1.1.4 fixed B-117 by upgrading `services/utils.ts:normalizeTrigger` to strip both leading and trailing colons (Espanso convention) and calling it inside `community-packages.ts:convertSnippetsToObject`. But `packages/espanso.ts` still had its OWN private `normalizeTrigger` that only stripped leading colons. After 1.1.4 the two functions had silently diverged in capability for no reason.

Removed the local copy from `espanso.ts`; both call sites now use the same `services/utils.ts` export. Behaviour stays correct — Espanso imports now also handle trailing colons, which is strictly an improvement (a hypothetical `:smile:` trigger in an Espanso YAML would now normalise to `smile` on import, just like community packs already do).

## 3. README — stop promising inline narrated video

`[![demo.gif](...)](demo.mp4)` rendered fine for the GIF auto-play, but the MP4 click-through turned out to just **download** the file (GitHub serves raw `.mp4` URLs with `application/octet-stream` content-type, so browsers refuse to play inline). The "Watch the 60-second walkthrough with voice-over" call-to-action was promising something GitHub couldn't deliver.

Reworded so the README is honest: the GIF is the inline asset, the MP4 lives at `docs/screens/demo.mp4` for users who want to download it and watch with sound. A future YouTube upload would let us embed a real player with audio; until that's set up, the copy doesn't oversell.

## Test plan

- [x] `npm test` — 325/325 pass (no test changes needed — DRY refactor preserves behaviour)
- [x] `npm run build` — clean
- [x] Visual smoke-tested in real Obsidian via `VAULT_PLUGIN=… npm run build:vault`: picker renders with grid layout, hover/selected states work, multi-line preview shows real line breaks, $| / $1 / $2 markers are visually distinct
- [ ] Visual smoke-test by reviewer

## Closes

- backlog B-115 (SnippetPickerModal CSS gap)
- partial cleanup follow-up to B-117 (DRY normalizeTrigger)

🤖 Generated with [Claude Code](https://claude.com/claude-code)