### PR TITLE
docs(readme): inline-playable demo video via GitHub user-attachment URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@
 
 > **Type `todo` and a space, get `- [ ]`.** Snipsy is the actively-maintained hotstring plugin for Obsidian — markdown-aware, with a community catalog and Espanso import. No scripting required.
 
-![Snipsy demo](docs/screens/demo.gif)
-
-> Silent GIF above. A 60-second narrated MP4 lives at [`docs/screens/demo.mp4`](docs/screens/demo.mp4) — GitHub serves it as a download, so save it locally or watch in your editor.
+<video src="https://github.com/user-attachments/assets/8e54d0ec-9b86-4741-b697-0a0a981a127b" autoplay muted loop playsinline width="100%">
+  <a href="docs/screens/demo.mp4">▶ Watch the 60-second narrated demo</a>
+</video>
 
 ---
 


### PR DESCRIPTION
## Summary

1.1.5 shipped the README with a silent GIF and an honest "MP4 downloads when clicked" note, because GitHub serves raw `.mp4` URLs from the repo with `application/octet-stream` content-type (browsers refuse to play them inline).

GitHub's **user-attachments** CDN solves this — files uploaded via drag-drop into a saved issue/PR/comment get hosted at `https://github.com/user-attachments/assets/<uuid>` URLs that redirect to signed S3 URLs with `response-content-type=video/mp4` baked in. Browsers play them inline; the assets live indefinitely as long as the parent issue/PR/comment stays.

`demo.mp4` is now hosted via #34 (a tracking issue we'll keep open as the parking spot for demo assets). The README embeds it via:

```html
<video src="https://github.com/user-attachments/assets/8e54d0ec-9b86-4741-b697-0a0a981a127b"
       autoplay muted loop playsinline width="100%">
  <a href="docs/screens/demo.mp4">▶ Watch the 60-second narrated demo</a>
</video>
```

Behaviour on github.com:
- Auto-plays muted on README open (same UX as a GIF, no click needed)
- "Volume" icon in the inline player lets users unmute to hear Andrew narrating
- Fallback `<a>` inside the tag handles environments where HTML is stripped (npm mirrors, some RSS readers) — still points at the in-repo MP4

## Test plan

- [x] Verified the attachment URL serves `video/mp4` via curl (`HTTP 302 → S3 signed URL with response-content-type=video%2Fmp4`)
- [ ] Visual: refresh github.com/Dimagious/snipsidian after merge → confirm video auto-plays muted

🤖 Generated with [Claude Code](https://claude.com/claude-code)