### PR TITLE
refactor(install): lift install-plan to core/ (1.1.6 PR 2, B-028 partial)

### DIFF
--- a/src/core/install-plan.test.ts
+++ b/src/core/install-plan.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect } from "vitest";
+import { buildPackageDiff, isPackageInstalled } from "./install-plan";
+
+describe("install-plan.buildPackageDiff", () => {
+    it("splits incoming snippets into added vs conflicts, prefixed by group", () => {
+        const incoming = { todo: "- [ ]", done: "- [x]" };
+        const current = { "Markdown/done": "- [DONE]" };
+        const diff = buildPackageDiff(incoming, "Markdown", current);
+
+        expect(diff.added).toEqual([{ key: "Markdown/todo", value: "- [ ]" }]);
+        expect(diff.conflicts).toEqual([
+            { key: "Markdown/done", incoming: "- [x]", current: "- [DONE]" },
+        ]);
+    });
+
+    it("returns empty added + conflicts for an empty incoming package", () => {
+        const diff = buildPackageDiff({}, "Anything", { foo: "bar" });
+        expect(diff.added).toEqual([]);
+        expect(diff.conflicts).toEqual([]);
+    });
+
+    it("skips entries that already match exactly (no-op re-install)", () => {
+        const incoming = { todo: "- [ ]" };
+        const current = { "Markdown/todo": "- [ ]" };
+        const diff = buildPackageDiff(incoming, "Markdown", current);
+        expect(diff.added).toEqual([]);
+        expect(diff.conflicts).toEqual([]);
+    });
+
+    it("applies group prefix via joinKey (no slashes leak into trigger keys)", () => {
+        // A package label with spaces in it should be passed through
+        // joinKey untouched; the diff produces `<label>/<trigger>` keys.
+        const diff = buildPackageDiff(
+            { hello: "world" },
+            "My Pack — Edition 2",
+            {},
+        );
+        expect(diff.added).toEqual([
+            { key: "My Pack — Edition 2/hello", value: "world" },
+        ]);
+    });
+
+    it("prototype-shaped trigger keys are passed through as plain own properties", () => {
+        // `validatePackageForInstall` rejects prototype-pollution attempts
+        // upstream, but pin the behaviour at this layer too: the diff
+        // function must not mutate Object.prototype and must report the
+        // weird keys as added under the group prefix.
+        //
+        // Use JSON.parse to construct the input — an object literal
+        // `{__proto__: ...}` would invoke the prototype setter rather
+        // than create an own property. JSON.parse is the realistic
+        // attack surface (YAML pack → object → here).
+        const before = Object.prototype.toString;
+        const incoming = JSON.parse(
+            '{"__proto__":"evil","constructor":"also evil"}',
+        ) as Record<string, string>;
+        const diff = buildPackageDiff(incoming, "Group", {});
+        expect(Object.prototype.toString).toBe(before);
+        const keys = diff.added.map((a) => a.key).sort();
+        expect(keys).toEqual(["Group/__proto__", "Group/constructor"].sort());
+    });
+});
+
+describe("install-plan.isPackageInstalled", () => {
+    it("returns true when 100% of triggers match (exact same values)", () => {
+        expect(
+            isPackageInstalled(
+                { a: "1", b: "2", c: "3" },
+                "Pack",
+                { "Pack/a": "1", "Pack/b": "2", "Pack/c": "3" },
+            ),
+        ).toBe(true);
+    });
+
+    it("returns false for undefined or empty snippet map", () => {
+        expect(isPackageInstalled(undefined, "Pack", { "Pack/a": "1" })).toBe(false);
+        expect(isPackageInstalled({}, "Pack", { "Pack/a": "1" })).toBe(false);
+    });
+
+    it("returns true at the 80% boundary (4 of 5 match)", () => {
+        const triggers = { a: "1", b: "2", c: "3", d: "4", e: "5" };
+        const current = {
+            "Pack/a": "1",
+            "Pack/b": "2",
+            "Pack/c": "3",
+            "Pack/d": "4",
+            // e missing — 4 of 5 = exactly 80%
+        };
+        expect(isPackageInstalled(triggers, "Pack", current)).toBe(true);
+    });
+
+    it("returns false just under the 80% boundary (3 of 5 match)", () => {
+        const triggers = { a: "1", b: "2", c: "3", d: "4", e: "5" };
+        const current = {
+            "Pack/a": "1",
+            "Pack/b": "2",
+            "Pack/c": "3",
+            // d, e missing — 3 of 5 = 60%
+        };
+        expect(isPackageInstalled(triggers, "Pack", current)).toBe(false);
+    });
+
+    it("counts a user-edited entry as NOT installed (value mismatch)", () => {
+        // If the user edited one entry in a 5-pack to a different
+        // replacement, that entry no longer counts toward the
+        // heuristic. 4 unedited of 5 = still installed (80% boundary).
+        const triggers = { a: "1", b: "2", c: "3", d: "4", e: "5" };
+        const current = {
+            "Pack/a": "1",
+            "Pack/b": "2",
+            "Pack/c": "3",
+            "Pack/d": "4",
+            "Pack/e": "USER EDIT", // value differs from pack
+        };
+        expect(isPackageInstalled(triggers, "Pack", current)).toBe(true);
+
+        // Two edits drops to 3/5 = 60% — flips to false.
+        const moreEdited = {
+            ...current,
+            "Pack/d": "USER EDIT 2",
+        };
+        expect(isPackageInstalled(triggers, "Pack", moreEdited)).toBe(false);
+    });
+
+    it("zero-trigger packages report false (matches the no-snippets-to-install Notice path)", () => {
+        expect(isPackageInstalled({}, "Pack", {})).toBe(false);
+    });
+});

--- a/src/core/install-plan.ts
+++ b/src/core/install-plan.ts
@@ -53,3 +53,33 @@ export function buildPackageDiff(
     }
     return diffIncoming(prefixed, currentSnippets);
 }
+
+/**
+ * Heuristic check: is this package "installed enough" to label its
+ * row as Installed in the Packages tab?
+ *
+ * Threshold is **≥ 80 % of the package's triggers** present in the
+ * current store AND with the exact same replacement. Keeps the
+ * Installed badge stable when the user has tweaked one or two
+ * entries — without this, any user edit would flip the button back
+ * to "Install" and tempt the user into wiping their changes.
+ *
+ * Note (1.1.6): B-017 / PR 3 will redefine "installed" entirely
+ * (key-presence only, no value comparison), so this heuristic is a
+ * transitional implementation matching what shipped before this
+ * extraction. The PR 3 change becomes a one-line edit here.
+ */
+export function isPackageInstalled(
+    newSnippets: Record<string, string> | undefined,
+    packageGroup: string,
+    currentSnippets: Record<string, string>,
+): boolean {
+    if (!newSnippets) return false;
+    const packageTriggers = Object.keys(newSnippets);
+    if (packageTriggers.length === 0) return false;
+    const installed = packageTriggers.filter((trigger) => {
+        const groupedKey = joinKey(packageGroup, trigger);
+        return currentSnippets[groupedKey] === newSnippets[trigger];
+    });
+    return installed.length >= packageTriggers.length * 0.8;
+}

--- a/src/core/install-plan.ts
+++ b/src/core/install-plan.ts
@@ -1,0 +1,55 @@
+/**
+ * Pure install-plan helpers for community packages.
+ *
+ * The community-pack install path needs two answers before it writes
+ * anything to settings:
+ *
+ *   1. **What would change?** — given a package's snippets and the
+ *      current store, classify each entry as "added" (key didn't exist)
+ *      or "conflict" (key existed with a different value). Drives the
+ *      diff preview modal.
+ *   2. **Is this package already installed?** — heuristic used by the
+ *      Packages tab to label the row's button as "Install" vs
+ *      "Installed" (and, with B-017 / B-042 in PR 3 of 1.1.6, to
+ *      offer Reinstall + Uninstall affordances).
+ *
+ * Both functions are **pure** — no `this.plugin`, no DOM, no `Notice`.
+ * That's the architectural point of this module: business logic out
+ * of UI handlers so the rules can be tested at the function boundary
+ * per [ADR-0005](.claude/brain/decisions/0005-test-philosophy.md).
+ *
+ * Extracted from `ui/components/community/PackageBrowser.ts` in 1.1.6
+ * (B-028, partial — `core/snippet-ops.ts` covering add/rename/delete/
+ * move is deferred to 1.2.0).
+ */
+
+import { joinKey } from "../store/keys";
+import { diffIncoming, type DiffResult } from "../store/diff";
+
+/**
+ * Compute the diff between a package's incoming snippets and the
+ * current snippet store, with each incoming trigger first prefixed by
+ * the package's group label via `joinKey`.
+ *
+ * @param newSnippets    pack-level `{ trigger: replacement }` map
+ *                       (triggers WITHOUT the group prefix)
+ * @param packageGroup   the package label used as the group prefix
+ *                       (e.g. "Markdown Essentials")
+ * @param currentSnippets the live `settings.snippets` map (with full
+ *                        `<group>/<trigger>` keys)
+ *
+ * The return shape is the shared `DiffResult` so the result can be
+ * fed directly into `PackagePreviewModal` and any other consumer of
+ * the diff.
+ */
+export function buildPackageDiff(
+    newSnippets: Record<string, string>,
+    packageGroup: string,
+    currentSnippets: Record<string, string>,
+): DiffResult {
+    const prefixed: Record<string, string> = {};
+    for (const [trigger, replacement] of Object.entries(newSnippets)) {
+        prefixed[joinKey(packageGroup, trigger)] = replacement;
+    }
+    return diffIncoming(prefixed, currentSnippets);
+}

--- a/src/ui/components/community/PackageBrowser.ts
+++ b/src/ui/components/community/PackageBrowser.ts
@@ -4,6 +4,7 @@ import { loadAllCommunityPackages } from "../../../services/community-packages";
 import { validatePackageForInstall } from "../../../services/package-validator";
 import { PackagePreviewModal } from "../Modals";
 import { joinKey } from "../../../store/keys";
+import { buildPackageDiff } from "../../../core/install-plan";
 import { hasReplacementCollision } from "../../../store/snippets";
 
 interface PackageItem {
@@ -267,7 +268,11 @@ export class PackageBrowser {
 
             // Always preview (HANDOFF §2d) — even with zero conflicts the
             // user should see the diff before the install happens.
-            const diff = this.buildPackageDiff(pkg.snippets, packageGroup);
+            const diff = buildPackageDiff(
+                pkg.snippets,
+                packageGroup,
+                this.plugin.settings.snippets,
+            );
             const modal = new PackagePreviewModal(this.app, this.plugin, pkg.label, diff);
             modal.onConfirm = async (resolved) => {
                 await this.applyResolvedInstallation(pkg, resolved);
@@ -278,29 +283,6 @@ export class PackageBrowser {
                 `Failed to install package: ${error instanceof Error ? error.message : String(error)}`,
             );
         }
-    }
-
-    private buildPackageDiff(
-        newSnippets: { [trigger: string]: string },
-        packageGroup: string,
-    ): {
-        added: Array<{ key: string; value: string }>;
-        conflicts: Array<{ key: string; current: string; incoming: string }>;
-    } {
-        const added: Array<{ key: string; value: string }> = [];
-        const conflicts: Array<{ key: string; current: string; incoming: string }> = [];
-
-        for (const [trigger, incoming] of Object.entries(newSnippets)) {
-            const groupedKey = joinKey(packageGroup, trigger);
-            const current = this.plugin.settings.snippets[groupedKey];
-            if (current === undefined) {
-                added.push({ key: groupedKey, value: incoming });
-            } else if (current !== incoming) {
-                conflicts.push({ key: groupedKey, current, incoming });
-            }
-        }
-
-        return { added, conflicts };
     }
 
     private async applyResolvedInstallation(

--- a/src/ui/components/community/PackageBrowser.ts
+++ b/src/ui/components/community/PackageBrowser.ts
@@ -4,7 +4,7 @@ import { loadAllCommunityPackages } from "../../../services/community-packages";
 import { validatePackageForInstall } from "../../../services/package-validator";
 import { PackagePreviewModal } from "../Modals";
 import { joinKey } from "../../../store/keys";
-import { buildPackageDiff } from "../../../core/install-plan";
+import { buildPackageDiff, isPackageInstalled } from "../../../core/install-plan";
 import { hasReplacementCollision } from "../../../store/snippets";
 
 interface PackageItem {
@@ -199,7 +199,11 @@ export class PackageBrowser {
         });
 
         const actions = row.createDiv({ cls: "package-actions" });
-        const installed = this.isPackageInstalled(pkg);
+        const installed = isPackageInstalled(
+            pkg.snippets,
+            pkg.label,
+            this.plugin.settings.snippets,
+        );
         const btn = actions.createEl("button", {
             text: installed ? "Installed" : "Install",
             cls: installed ? "snippet-action" : "snippet-action mod-cta",
@@ -302,22 +306,6 @@ export class PackageBrowser {
         }
     }
 
-    private isPackageInstalled(pkg: PackageItem): boolean {
-        if (!pkg.snippets) return false;
-        const packageGroup = pkg.label;
-        const packageTriggers = Object.keys(pkg.snippets);
-        if (packageTriggers.length === 0) return false;
-        // Same install-heuristic as before: ≥80% of the package's
-        // snippets present in the group is "installed". Keeps the
-        // install badge stable when the user has tweaked one or two
-        // entries.
-        const installed = packageTriggers.filter((trigger) => {
-            const groupedKey = joinKey(packageGroup, trigger);
-            return this.plugin.settings.snippets[groupedKey] === pkg.snippets![trigger];
-        });
-        return installed.length >= packageTriggers.length * 0.8;
-    }
-
     private showPackageDetails(pkg: PackageItem) {
         const modal = new Modal(this.app);
         modal.titleEl.setText(pkg.label);
@@ -356,7 +344,11 @@ export class PackageBrowser {
         }
 
         const footer = content.createDiv({ cls: "modal-button-container" });
-        const installed = this.isPackageInstalled(pkg);
+        const installed = isPackageInstalled(
+            pkg.snippets,
+            pkg.label,
+            this.plugin.settings.snippets,
+        );
         const installBtn = footer.createEl("button", {
             text: installed ? "Installed" : "Install",
             cls: installed ? "" : "mod-cta",


### PR DESCRIPTION
**1.1.6 PR 2 of 3.** Builds on #37 (B-026). Plan: \`.claude/brain/sessions/2026-05-21-1.1.6-plan.md\` (local-only).

## Summary

Lifts the two install-plan helpers out of \`PackageBrowser\`'s UI handler into a new pure \`src/core/install-plan.ts\`:

- **\`buildPackageDiff(newSnippets, packageGroup, currentSnippets) → DiffResult\`** — computes added vs conflicts after prefixing each incoming trigger via \`joinKey(packageGroup, …)\`. Implemented in terms of \`diffIncoming\` + \`joinKey\` so the relationship between package-level diff and underlying snippet-map diff is explicit.
- **\`isPackageInstalled(newSnippets, packageGroup, currentSnippets) → boolean\`** — ≥80% match heuristic preserved verbatim. The function is the **one place** PR 3 (B-017) will edit to redefine "installed" as key-presence only.

Both functions are pure — no \`this.plugin\`, no DOM, no \`Notice\`. \`PackageBrowser\` no longer owns install-plan logic; it just passes \`pkg.snippets\`, \`pkg.label\`, and \`this.plugin.settings.snippets\` into the exported helpers and consumes \`DiffResult\`.

## Why this PR

PR 3 (B-017) redefines what "installed" means. With the heuristic inside a \`PackageBrowser\` private method, the fix lives behind a click — untestable in isolation. With the logic in \`core/install-plan.ts\`, the fix becomes a one-line edit pinned by 11 boundary tests at the function boundary, per [ADR-0005](.claude/brain/decisions/0005-test-philosophy.md).

## Boundary tests (11 cases)

**\`buildPackageDiff\`:**
- happy path (added + conflicts mix with group prefix)
- empty incoming package
- no-op re-install (entries that already match exactly)
- group labels with spaces / em-dash passed through \`joinKey\` untouched
- prototype-shaped keys (\`__proto__\`, \`constructor\`) from a \`JSON.parse\`'d input — defence-in-depth pin behind \`validatePackageForInstall\`

**\`isPackageInstalled\`:**
- 100% match → true
- undefined or empty snippet map → false
- 80% boundary (4 of 5) → true at threshold
- 79% boundary (3 of 5) → false just below
- user-edited entry counts as not installed (value mismatch); one edit OK, two edits flip the badge
- zero-trigger package → false

\`core/install-plan.ts\`: **100% line + branch + function coverage**.

## Test plan

- [x] \`npx tsc -p tsconfig.json --noEmit\` — clean
- [x] \`npm test\` — 336/336 (was 325 on main; +11 from \`install-plan.test.ts\`)
- [x] \`npm run build\` — main.js 180.5kb (~unchanged)
- [ ] CI green

## Risk

Medium. Refactoring the install code path that PR 3 will then re-test from a different angle. The test suite is the safety net — the 11 boundary cases pin exactly the behaviour PR 3 will change vs the behaviour PR 3 must preserve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)