### PR TITLE
fix(install): redefine "installed" + add Reinstall/Uninstall (1.1.6 PR 3, B-017 P0 + B-042)

### DIFF
--- a/src/core/install-plan.test.ts
+++ b/src/core/install-plan.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { buildPackageDiff, isPackageInstalled } from "./install-plan";
+import {
+    buildPackageDiff,
+    isPackageInstalled,
+    listPackageKeys,
+    removePackageSnippets,
+} from "./install-plan";
 
 describe("install-plan.buildPackageDiff", () => {
     it("splits incoming snippets into added vs conflicts, prefixed by group", () => {
@@ -146,5 +151,96 @@ describe("install-plan.isPackageInstalled (B-017: key-presence only)", () => {
         expect(diff.conflicts).toEqual([
             { key: "Markdown/todo", incoming: "- [ ]", current: "- [ ] !!!" },
         ]);
+    });
+});
+
+describe("install-plan.listPackageKeys", () => {
+    it("returns every key shaped `<packageGroup>/*`", () => {
+        const current = {
+            "Pack/a": "1",
+            "Pack/b": "2",
+            "Other/a": "3",
+            "noprefix": "4",
+        };
+        expect(listPackageKeys("Pack", current).sort()).toEqual([
+            "Pack/a",
+            "Pack/b",
+        ]);
+    });
+
+    it("does NOT match `<packageGroup>` as a literal key (without slash)", () => {
+        // A snippet at the bare key "Pack" is not a member of group
+        // "Pack" — keys must be `Pack/<trigger>` to belong.
+        const current = { Pack: "lone", "Pack/a": "1" };
+        expect(listPackageKeys("Pack", current)).toEqual(["Pack/a"]);
+    });
+
+    it("does NOT match a group whose name starts with `<packageGroup>`", () => {
+        // "Pack2/foo" should NOT match group "Pack" — the slash
+        // boundary in the prefix prevents this kind of bleed.
+        const current = { "Pack/a": "1", "Pack2/a": "1" };
+        expect(listPackageKeys("Pack", current)).toEqual(["Pack/a"]);
+    });
+
+    it("returns empty array for an empty store or empty group", () => {
+        expect(listPackageKeys("Pack", {})).toEqual([]);
+        expect(listPackageKeys("", { "Pack/a": "1" })).toEqual([]);
+    });
+});
+
+describe("install-plan.removePackageSnippets", () => {
+    it("returns a NEW map without the package's keys; input is not mutated", () => {
+        const current = {
+            "Pack/a": "1",
+            "Pack/b": "2",
+            "Other/a": "3",
+        };
+        const next = removePackageSnippets("Pack", current);
+        expect(next).toEqual({ "Other/a": "3" });
+        // Original untouched
+        expect(current).toEqual({
+            "Pack/a": "1",
+            "Pack/b": "2",
+            "Other/a": "3",
+        });
+        expect(next).not.toBe(current);
+    });
+
+    it("preserves keys from other groups and bare-key snippets", () => {
+        const current = {
+            "Pack/a": "1",
+            "Other/x": "x",
+            standalone: "s",
+        };
+        expect(removePackageSnippets("Pack", current)).toEqual({
+            "Other/x": "x",
+            standalone: "s",
+        });
+    });
+
+    it("removes user-edited entries within the group (uninstall = no trace)", () => {
+        // The user edited "Pack/a" to "USER" — uninstall still
+        // removes it. That's by design: edits to a pack's own keys
+        // are conceptually "the user's version of this pack", and
+        // uninstall should leave no trace of the pack.
+        const current = {
+            "Pack/a": "USER",
+            "Pack/b": "2",
+        };
+        expect(removePackageSnippets("Pack", current)).toEqual({});
+    });
+
+    it("returns a shallow copy when the package has no keys present", () => {
+        const current = { "Other/a": "1" };
+        const next = removePackageSnippets("Pack", current);
+        expect(next).toEqual({ "Other/a": "1" });
+        expect(next).not.toBe(current);
+    });
+
+    it("returns a shallow copy when packageGroup is empty (defensive)", () => {
+        const current = { "Pack/a": "1" };
+        const next = removePackageSnippets("", current);
+        expect(next).toEqual({ "Pack/a": "1" });
+        expect(next).not.toBe(current);
     });
 });

--- a/src/core/install-plan.test.ts
+++ b/src/core/install-plan.test.ts
@@ -61,8 +61,18 @@ describe("install-plan.buildPackageDiff", () => {
     });
 });
 
-describe("install-plan.isPackageInstalled", () => {
-    it("returns true when 100% of triggers match (exact same values)", () => {
+describe("install-plan.isPackageInstalled (B-017: key-presence only)", () => {
+    it("returns true when at least one pack key is present in current snippets", () => {
+        expect(
+            isPackageInstalled(
+                { a: "1", b: "2", c: "3" },
+                "Pack",
+                { "Pack/a": "1" },
+            ),
+        ).toBe(true);
+    });
+
+    it("returns true at 100% match (every key + value identical)", () => {
         expect(
             isPackageInstalled(
                 { a: "1", b: "2", c: "3" },
@@ -77,52 +87,64 @@ describe("install-plan.isPackageInstalled", () => {
         expect(isPackageInstalled({}, "Pack", { "Pack/a": "1" })).toBe(false);
     });
 
-    it("returns true at the 80% boundary (4 of 5 match)", () => {
+    it("ignores values entirely — any pack key with ANY value counts as installed (B-017)", () => {
+        // The old ≥80%-value-match heuristic flipped the badge back
+        // to "Install" the moment the user edited a few rows, which
+        // tempted them to re-install and silently lose their edits.
+        // The new contract: user edits are still "installed".
+        expect(
+            isPackageInstalled(
+                { a: "1", b: "2", c: "3" },
+                "Pack",
+                { "Pack/a": "USER EDIT", "Pack/b": "USER EDIT 2", "Pack/c": "USER EDIT 3" },
+            ),
+        ).toBe(true);
+    });
+
+    it("returns true with only 1 of N keys present (partial install / partial uninstall)", () => {
         const triggers = { a: "1", b: "2", c: "3", d: "4", e: "5" };
         const current = {
             "Pack/a": "1",
-            "Pack/b": "2",
-            "Pack/c": "3",
-            "Pack/d": "4",
-            // e missing — 4 of 5 = exactly 80%
+            // b, c, d, e all missing — 1 of 5 still counts
         };
         expect(isPackageInstalled(triggers, "Pack", current)).toBe(true);
     });
 
-    it("returns false just under the 80% boundary (3 of 5 match)", () => {
-        const triggers = { a: "1", b: "2", c: "3", d: "4", e: "5" };
+    it("returns false when NO pack key is present (matches the fresh-install case)", () => {
+        const triggers = { a: "1", b: "2" };
         const current = {
-            "Pack/a": "1",
-            "Pack/b": "2",
-            "Pack/c": "3",
-            // d, e missing — 3 of 5 = 60%
+            // None of the Pack/* keys present
+            "OtherPack/a": "1",
+            "OtherPack/b": "2",
         };
         expect(isPackageInstalled(triggers, "Pack", current)).toBe(false);
     });
 
-    it("counts a user-edited entry as NOT installed (value mismatch)", () => {
-        // If the user edited one entry in a 5-pack to a different
-        // replacement, that entry no longer counts toward the
-        // heuristic. 4 unedited of 5 = still installed (80% boundary).
-        const triggers = { a: "1", b: "2", c: "3", d: "4", e: "5" };
-        const current = {
-            "Pack/a": "1",
-            "Pack/b": "2",
-            "Pack/c": "3",
-            "Pack/d": "4",
-            "Pack/e": "USER EDIT", // value differs from pack
-        };
-        expect(isPackageInstalled(triggers, "Pack", current)).toBe(true);
-
-        // Two edits drops to 3/5 = 60% — flips to false.
-        const moreEdited = {
-            ...current,
-            "Pack/d": "USER EDIT 2",
-        };
-        expect(isPackageInstalled(triggers, "Pack", moreEdited)).toBe(false);
-    });
-
     it("zero-trigger packages report false (matches the no-snippets-to-install Notice path)", () => {
         expect(isPackageInstalled({}, "Pack", {})).toBe(false);
+    });
+
+    it("[B-017 regression] user-edited row surfaces as a conflict in buildPackageDiff so reinstall preserves it by default", () => {
+        // The end-to-end behaviour B-017 is about: user installed
+        // a pack, edited one row, then reinstalls. The diff must
+        // surface the edit as a CONFLICT (not silently overwrite).
+        // PackagePreviewModal then renders the conflict with
+        // "Keep current" as the default, so a click-through
+        // "Reinstall → Apply" preserves the user's edit.
+        const pack = { todo: "- [ ]", done: "- [x]" };
+        const current = {
+            "Markdown/todo": "- [ ] !!!", // user edit
+            "Markdown/done": "- [x]",     // untouched
+        };
+
+        // The pack is still considered installed even with the edit.
+        expect(isPackageInstalled(pack, "Markdown", current)).toBe(true);
+
+        // And the diff shows the edit as a recoverable conflict.
+        const diff = buildPackageDiff(pack, "Markdown", current);
+        expect(diff.added).toEqual([]);
+        expect(diff.conflicts).toEqual([
+            { key: "Markdown/todo", incoming: "- [ ]", current: "- [ ] !!!" },
+        ]);
     });
 });

--- a/src/core/install-plan.ts
+++ b/src/core/install-plan.ts
@@ -55,19 +55,19 @@ export function buildPackageDiff(
 }
 
 /**
- * Heuristic check: is this package "installed enough" to label its
- * row as Installed in the Packages tab?
+ * Is this package installed? Answers the row-button-label question
+ * in the Packages tab.
  *
- * Threshold is **≥ 80 % of the package's triggers** present in the
- * current store AND with the exact same replacement. Keeps the
- * Installed badge stable when the user has tweaked one or two
- * entries — without this, any user edit would flip the button back
- * to "Install" and tempt the user into wiping their changes.
+ * **Definition (1.1.6, B-017):** any key under `<packageGroup>/*`
+ * present in the snippet store. We do NOT compare values: the user
+ * may have edited some entries, and edits must not flip the badge
+ * back to "Install" — that's the original P0 footgun (B-017) where
+ * the disabled "Already installed" button left users with no path
+ * to refresh from upstream and tempted them to "Install" again,
+ * which silently overwrote their edits.
  *
- * Note (1.1.6): B-017 / PR 3 will redefine "installed" entirely
- * (key-presence only, no value comparison), so this heuristic is a
- * transitional implementation matching what shipped before this
- * extraction. The PR 3 change becomes a one-line edit here.
+ * Pre-1.1.6 used a ≥80 % value-match heuristic. That heuristic is
+ * the one this redefinition replaces.
  */
 export function isPackageInstalled(
     newSnippets: Record<string, string> | undefined,
@@ -77,9 +77,8 @@ export function isPackageInstalled(
     if (!newSnippets) return false;
     const packageTriggers = Object.keys(newSnippets);
     if (packageTriggers.length === 0) return false;
-    const installed = packageTriggers.filter((trigger) => {
+    return packageTriggers.some((trigger) => {
         const groupedKey = joinKey(packageGroup, trigger);
-        return currentSnippets[groupedKey] === newSnippets[trigger];
+        return currentSnippets[groupedKey] !== undefined;
     });
-    return installed.length >= packageTriggers.length * 0.8;
 }

--- a/src/core/install-plan.ts
+++ b/src/core/install-plan.ts
@@ -82,3 +82,48 @@ export function isPackageInstalled(
         return currentSnippets[groupedKey] !== undefined;
     });
 }
+
+/**
+ * List the full snippet keys that belong to a given package group —
+ * i.e. every key shaped `<packageGroup>/*` currently in the store.
+ *
+ * Used to:
+ *   - render the Uninstall confirmation modal (B-053 fold-in: show
+ *     the first N trigger names of what will be removed)
+ *   - drive `removePackageSnippets` below
+ *
+ * Package labels are validated to reject `/` (see package-validator
+ * S-006), so the `<group>/<trigger>` prefix is unambiguous.
+ */
+export function listPackageKeys(
+    packageGroup: string,
+    currentSnippets: Record<string, string>,
+): string[] {
+    if (!packageGroup) return [];
+    const prefix = `${packageGroup}/`;
+    return Object.keys(currentSnippets).filter((k) => k.startsWith(prefix));
+}
+
+/**
+ * Return a NEW snippet map with every `<packageGroup>/*` key removed.
+ * The input map is not mutated — callers replace
+ * `settings.snippets` with the returned value and persist.
+ *
+ * Removes the user's edits to the package's keys as well as the
+ * package's own entries. That's by design: those edits were
+ * conceptually "the user's version of this pack", and uninstalling
+ * a pack should leave no trace of it. If the user wants to keep
+ * something, they rename it out of the package group first.
+ */
+export function removePackageSnippets(
+    packageGroup: string,
+    currentSnippets: Record<string, string>,
+): Record<string, string> {
+    if (!packageGroup) return { ...currentSnippets };
+    const prefix = `${packageGroup}/`;
+    const result: Record<string, string> = {};
+    for (const [k, v] of Object.entries(currentSnippets)) {
+        if (!k.startsWith(prefix)) result[k] = v;
+    }
+    return result;
+}

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -308,6 +308,8 @@
 }
 .snipsidian-settings .package-row .package-actions {
   flex: 0 0 auto;
+  display: flex;
+  gap: 6px;
 }
 .snipsidian-settings .package-name-line {
   display: flex;

--- a/src/ui/components/community/PackageBrowser.ts
+++ b/src/ui/components/community/PackageBrowser.ts
@@ -2,9 +2,14 @@ import { App, Modal, Notice } from "obsidian";
 import type SnipSidianPlugin from "../../../main";
 import { loadAllCommunityPackages } from "../../../services/community-packages";
 import { validatePackageForInstall } from "../../../services/package-validator";
-import { PackagePreviewModal } from "../Modals";
-import { joinKey } from "../../../store/keys";
-import { buildPackageDiff, isPackageInstalled } from "../../../core/install-plan";
+import { ConfirmModal, PackagePreviewModal } from "../Modals";
+import { joinKey, splitKey } from "../../../store/keys";
+import {
+    buildPackageDiff,
+    isPackageInstalled,
+    listPackageKeys,
+    removePackageSnippets,
+} from "../../../core/install-plan";
 import { hasReplacementCollision } from "../../../store/snippets";
 
 interface PackageItem {
@@ -204,18 +209,52 @@ export class PackageBrowser {
             pkg.label,
             this.plugin.settings.snippets,
         );
-        const btn = actions.createEl("button", {
-            text: installed ? "Installed" : "Install",
-            cls: installed ? "snippet-action" : "snippet-action mod-cta",
-            attr: { type: "button" },
-        });
+
         if (installed) {
-            btn.disabled = true;
+            // B-042: replace the dead-end "Installed" disabled state
+            // with two affordances. Reinstall re-routes through the
+            // preview modal so user edits surface as conflicts with
+            // "Keep current" defaulted (B-017). Uninstall removes
+            // all of the pack's keys after a confirmation modal.
+            const reinstallBtn = actions.createEl("button", {
+                text: "Reinstall",
+                cls: "snippet-action",
+                attr: {
+                    type: "button",
+                    "aria-label": `Reinstall ${pkg.label}`,
+                },
+            });
+            reinstallBtn.addEventListener("click", (e) => {
+                e.stopPropagation();
+                this.installPackage(pkg);
+            });
+
+            const uninstallBtn = actions.createEl("button", {
+                text: "Uninstall",
+                cls: "snippet-action",
+                attr: {
+                    type: "button",
+                    "aria-label": `Uninstall ${pkg.label}`,
+                },
+            });
+            uninstallBtn.addEventListener("click", (e) => {
+                e.stopPropagation();
+                this.uninstallPackage(pkg);
+            });
+        } else {
+            const btn = actions.createEl("button", {
+                text: "Install",
+                cls: "snippet-action mod-cta",
+                attr: {
+                    type: "button",
+                    "aria-label": `Install ${pkg.label}`,
+                },
+            });
+            btn.addEventListener("click", (e) => {
+                e.stopPropagation();
+                this.installPackage(pkg);
+            });
         }
-        btn.addEventListener("click", (e) => {
-            e.stopPropagation();
-            if (!installed) this.installPackage(pkg);
-        });
 
         const openDetails = () => this.showPackageDetails(pkg);
         row.addEventListener("click", openDetails);
@@ -349,12 +388,31 @@ export class PackageBrowser {
             pkg.label,
             this.plugin.settings.snippets,
         );
-        const installBtn = footer.createEl("button", {
-            text: installed ? "Installed" : "Install",
-            cls: installed ? "" : "mod-cta",
-        });
-        installBtn.disabled = installed;
-        if (!installed) {
+        if (installed) {
+            // B-042: same affordances as the row (Reinstall +
+            // Uninstall) instead of a disabled "Installed" button.
+            const reinstallBtn = footer.createEl("button", {
+                text: "Reinstall",
+                attr: { "aria-label": `Reinstall ${pkg.label}` },
+            });
+            reinstallBtn.onclick = () => {
+                modal.close();
+                this.installPackage(pkg);
+            };
+            const uninstallBtn = footer.createEl("button", {
+                text: "Uninstall",
+                attr: { "aria-label": `Uninstall ${pkg.label}` },
+            });
+            uninstallBtn.onclick = () => {
+                modal.close();
+                this.uninstallPackage(pkg);
+            };
+        } else {
+            const installBtn = footer.createEl("button", {
+                text: "Install",
+                cls: "mod-cta",
+                attr: { "aria-label": `Install ${pkg.label}` },
+            });
             installBtn.onclick = () => {
                 modal.close();
                 this.installPackage(pkg);
@@ -363,5 +421,56 @@ export class PackageBrowser {
         footer.createEl("button", { text: "Close" }).onclick = () => modal.close();
 
         modal.open();
+    }
+
+    /**
+     * Uninstall flow (B-042): list the package's keys, confirm with
+     * the user (showing the first 5 trigger names per B-053), then
+     * apply `removePackageSnippets` and persist.
+     */
+    private uninstallPackage(pkg: PackageItem) {
+        const packageGroup = pkg.label;
+        const keys = listPackageKeys(packageGroup, this.plugin.settings.snippets);
+        if (keys.length === 0) {
+            new Notice(`"${pkg.label}" is not installed.`);
+            return;
+        }
+
+        const triggerNames = keys.map((k) => splitKey(k).name);
+        const sample = triggerNames.slice(0, 5).join(", ");
+        const more =
+            triggerNames.length > 5
+                ? ` (and ${triggerNames.length - 5} more)`
+                : "";
+        const message =
+            `This will remove ${keys.length} snippet${keys.length === 1 ? "" : "s"}` +
+            ` from "${pkg.label}": ${sample}${more}.\n\nThis cannot be undone.`;
+
+        new ConfirmModal(this.app, {
+            title: `Uninstall ${pkg.label}?`,
+            message,
+            confirmText: "Uninstall",
+            onConfirm: async () => {
+                try {
+                    this.plugin.settings.snippets = removePackageSnippets(
+                        packageGroup,
+                        this.plugin.settings.snippets,
+                    );
+                    await this.plugin.saveSettings();
+                    new Notice(
+                        `Uninstalled ${pkg.label} (${keys.length} snippet${
+                            keys.length === 1 ? "" : "s"
+                        } removed)`,
+                    );
+                    this.renderList();
+                } catch (error) {
+                    new Notice(
+                        `Failed to uninstall package: ${
+                            error instanceof Error ? error.message : String(error)
+                        }`,
+                    );
+                }
+            },
+        }).open();
     }
 }


### PR DESCRIPTION
**1.1.6 PR 3 of 3 — the user-facing fix.** Builds on #37 (B-026) and #38 (B-028). Plan: \`.claude/brain/sessions/2026-05-21-1.1.6-plan.md\` (local-only).

## Summary

Closes the **P0 (B-017)** silent-overwrite footgun and the dead-end "Already installed" disabled button it created. With the install-plan logic in pure functions (thanks to #38), the actual fix is small and the regression is pinned at the function boundary.

### The bug (B-017)

Pre-1.1.6:

1. User installs a community pack
2. User edits 2+ rows of that pack to tune them
3. The ≥ 80 %-value-match heuristic flips the row's badge from "Installed" back to "Install" (those edits no longer match the upstream values)
4. User clicks the now-active button → preview modal opens → user clicks "Apply" → user's edits silently overwritten by upstream
5. There was no other path back to upstream — disabled "Installed" left no resync affordance — so step 4 was the only thing users could do

### The fix

- **\`isPackageInstalled\` redefined** (commit 1): a pack is "installed" iff any of its keys exist under \`<packageGroup>/*\` in the snippet store. **Values are no longer compared.** User edits don't move the state machine.
- **\`listPackageKeys\` + \`removePackageSnippets\` pure helpers** (commit 2) for the Uninstall flow — full boundary coverage incl. prefix-boundary safety (\`Pack2/foo\` does not match \`Pack\`).
- **Reinstall + Uninstall affordances** (commit 3) replace the disabled "Installed" button in both the row and the Package Details modal. Reinstall re-routes through \`PackagePreviewModal\` so the user's edits surface as conflicts with **"Keep current" defaulted** — a click-through "Reinstall → Apply" preserves edits by default. Uninstall opens a \`ConfirmModal\` listing the first 5 trigger names that will be removed (B-053 fold-in), then on confirm strips every \`<packageGroup>/*\` key.

### Regression test (B-017)

\`install-plan.test.ts\` now pins the full chain at the function-boundary level:

\`\`\`ts
it("[B-017 regression] user-edited row surfaces as a conflict in buildPackageDiff so reinstall preserves it by default", () => {
    const pack = { todo: "- [ ]", done: "- [x]" };
    const current = {
        "Markdown/todo": "- [ ] !!!", // user edit
        "Markdown/done": "- [x]",
    };
    expect(isPackageInstalled(pack, "Markdown", current)).toBe(true);
    const diff = buildPackageDiff(pack, "Markdown", current);
    expect(diff.added).toEqual([]);
    expect(diff.conflicts).toEqual([
        { key: "Markdown/todo", incoming: "- [ ]", current: "- [ ] !!!" },
    ]);
});
\`\`\`

If anyone ever puts the ≥ 80 % heuristic back, this test fails.

### Migration

Users on 1.1.5 currently in the "Installed" state stay "Installed" — any pack key still in their store still counts under the new definition. No data migration needed.

### Coverage

- \`install-plan.test.ts\`: 22 boundary cases (was 11 in #38), 100 % line + branch + function coverage on \`core/install-plan.ts\`
- All 347/347 tests pass (was 338 on main; +9 from the new helpers and the redefinition-update tests)
- main.js: 180.5kb → 182.1kb (+1.6kb — uninstall flow + ConfirmModal wiring)

### What's deferred

- **E2E install-edit-reinstall spec.** The function-boundary regression above pins the *contract*, but a Playwright-driven end-to-end would also be useful. Defer to a follow-up: requires GitHub-API network call (currently flaky for CI determinism) and the demo/article-clips fixture changes are still on the unmerged PR #36. Will revisit once that lands or once we wire a mock for community-packages.

## Touch surface

- \`src/core/install-plan.ts\` — \`isPackageInstalled\` redefined; \`listPackageKeys\` + \`removePackageSnippets\` added
- \`src/core/install-plan.test.ts\` — 22 tests (11 added, some rewritten)
- \`src/ui/components/community/PackageBrowser.ts\` — row + Package Details footer rendering split; new \`uninstallPackage\` private method
- \`src/styles/main.css\` — \`.package-actions\` becomes \`display: flex; gap: 6px\` so the two buttons sit alongside each other

## Test plan

- [x] \`npx tsc -p tsconfig.json --noEmit\` — clean
- [x] \`npm test\` — 347/347 (was 338 on main)
- [x] \`npm run build\` — main.js 182.1kb
- [ ] Manual smoke in a vault:
  - [ ] Install a community pack → preview modal opens → Apply → row shows Reinstall + Uninstall
  - [ ] Edit one row of the pack → row still shows Reinstall + Uninstall (badge does NOT flip back to Install)
  - [ ] Click Reinstall → preview modal opens → edited row shows as conflict with "Keep current" selected → Apply → edit survives
  - [ ] Click Reinstall again → choose "Overwrite" on the conflict → Apply → edit replaced with upstream value
  - [ ] Click Uninstall → confirmation modal lists first 5 trigger names → Cancel → no change
  - [ ] Click Uninstall → confirmation modal → Uninstall → all pack keys gone, row shows Install again
- [ ] CI green

## Risk

Medium-High — this is the P0 fix. The 22 boundary tests + the regression test are the safety net. Worth doing the manual smoke before merging since the install path is one of the more visible features.

🤖 Generated with [Claude Code](https://claude.com/claude-code)