### PR TITLE
fix(packages): PackagePreviewModal bulk-action buttons no longer duplicate the modal DOM

### DIFF
--- a/src/ui/components/Modals.ts
+++ b/src/ui/components/Modals.ts
@@ -62,13 +62,19 @@ export class PackagePreviewModal extends Modal {
         });
 
         if (this.diff.conflicts.length) {
-            new Setting(contentEl)
-                .setHeading()
-                .setName("Conflicts");
+            contentEl.createEl("h3", { text: "Conflicts" });
             const table = contentEl.createEl("table", { cls: "snipsidian-preview-table" });
             const thead = table.createEl("thead");
             const headRow = thead.createEl("tr");
             ["Trigger", "Current", "Incoming", "Action"].forEach((h) => headRow.createEl("th", { text: h }));
+
+            // Keep a handle to each conflict's <select> so the bulk
+            // actions ("Keep all current" / "Overwrite all") can
+            // update them in place instead of re-rendering. The
+            // previous close()+open() trick double-rendered because
+            // Obsidian's Modal.close() doesn't synchronously empty
+            // contentEl, so onOpen() ran a second time and appended.
+            const selects: Array<{ key: string; el: HTMLSelectElement }> = [];
 
             const tbody = table.createEl("tbody");
             for (const c of this.diff.conflicts) {
@@ -82,19 +88,21 @@ export class PackagePreviewModal extends Modal {
                 sel.append(new Option("Keep current", "keep"), new Option("Overwrite", "overwrite"));
                 sel.value = this.choices.get(c.key) ?? "keep";
                 sel.onchange = () => this.choices.set(c.key, sel.value as "keep" | "overwrite");
+                selects.push({ key: c.key, el: sel });
             }
+
+            const setAll = (choice: "keep" | "overwrite") => {
+                for (const { key, el } of selects) {
+                    this.choices.set(key, choice);
+                    el.value = choice;
+                }
+            };
 
             const bulk = contentEl.createDiv({ cls: "snipsidian-bulk-actions" });
             const btnKeepAll = bulk.createEl("button", { text: "Keep all current" });
-            btnKeepAll.onclick = () => {
-                for (const k of this.choices.keys()) this.choices.set(k, "keep");
-                this.close(); this.open();
-            };
+            btnKeepAll.onclick = () => setAll("keep");
             const btnOverwriteAll = bulk.createEl("button", { text: "Overwrite all" });
-            btnOverwriteAll.onclick = () => {
-                for (const k of this.choices.keys()) this.choices.set(k, "overwrite");
-                this.close(); this.open();
-            };
+            btnOverwriteAll.onclick = () => setAll("overwrite");
         }
 
         const footer = contentEl.createDiv({ cls: "modal-button-container" });

--- a/src/ui/components/PackagePreviewModal.test.ts
+++ b/src/ui/components/PackagePreviewModal.test.ts
@@ -1,0 +1,174 @@
+// @vitest-environment jsdom
+
+import { describe, it, expect, beforeAll, beforeEach } from "vitest";
+import { installObsidianDomHelpers } from "../../test/dom-polyfill";
+import { makeMockPlugin } from "../../test/factories/plugin";
+import { PackagePreviewModal } from "./Modals";
+import type { DiffResult } from "../../store/diff";
+import type SnipSidianPlugin from "../../../main";
+
+/**
+ * Mount tests for PackagePreviewModal — the conflict-resolution UI
+ * that the install / Reinstall flow opens after `buildPackageDiff`.
+ *
+ * Pins the bulk-action contract that used to break visibly in
+ * production (PR #40, post-1.1.5): clicking "Keep all current" or
+ * "Overwrite all" was implemented as `close(); open();`, which in
+ * the real Obsidian Modal lifecycle re-runs `onOpen` without first
+ * emptying `contentEl` — every bulk click appended a duplicate
+ * summary + conflicts table + footer.
+ *
+ * The fix mutates each conflict's `<select>` element in place
+ * (no close+open). These tests pin the new behaviour.
+ */
+
+beforeAll(() => {
+    installObsidianDomHelpers();
+});
+
+let plugin: ReturnType<typeof makeMockPlugin>;
+beforeEach(() => {
+    document.body.innerHTML = "";
+    plugin = makeMockPlugin();
+});
+
+function mount(diff: DiffResult): PackagePreviewModal {
+    const modal = new PackagePreviewModal(
+        plugin.app,
+        plugin as unknown as SnipSidianPlugin,
+        "Markdown Essentials",
+        diff,
+    );
+    modal.open();
+    return modal;
+}
+
+function makeDiff(conflictCount: number, added = 0): DiffResult {
+    return {
+        added: Array.from({ length: added }, (_, i) => ({
+            key: `Pack/new${i}`,
+            value: `v${i}`,
+        })),
+        conflicts: Array.from({ length: conflictCount }, (_, i) => ({
+            key: `Pack/c${i}`,
+            current: `local-${i}`,
+            incoming: `upstream-${i}`,
+        })),
+    };
+}
+
+describe("PackagePreviewModal — bulk actions update selects in place", () => {
+    it("'Overwrite all' sets every <select>.value to 'overwrite' without re-rendering", () => {
+        const modal = mount(makeDiff(3));
+
+        const summariesBefore =
+            modal.contentEl.querySelectorAll(".modal-button-container").length;
+        const selectsBefore = modal.contentEl.querySelectorAll(
+            ".conflict-action select",
+        );
+        expect(selectsBefore.length).toBe(3);
+        // Initial state: all default to "keep"
+        for (const s of selectsBefore) {
+            expect((s as HTMLSelectElement).value).toBe("keep");
+        }
+
+        const overwriteAll = Array.from(
+            modal.contentEl.querySelectorAll<HTMLButtonElement>(
+                ".snipsidian-bulk-actions button",
+            ),
+        ).find((b) => b.textContent === "Overwrite all");
+        if (!overwriteAll) throw new Error("'Overwrite all' button not found");
+        overwriteAll.click();
+
+        // Selects updated to "overwrite"
+        const selectsAfter = modal.contentEl.querySelectorAll(
+            ".conflict-action select",
+        );
+        for (const s of selectsAfter) {
+            expect((s as HTMLSelectElement).value).toBe("overwrite");
+        }
+
+        // No DOM duplication: still exactly one footer (the regression
+        // against the close()+open() bug — that path appended a second
+        // footer / table / summary line on every bulk click).
+        const summariesAfter =
+            modal.contentEl.querySelectorAll(".modal-button-container").length;
+        expect(summariesAfter).toBe(summariesBefore);
+        expect(summariesAfter).toBe(1);
+
+        // Still exactly one conflicts table.
+        expect(
+            modal.contentEl.querySelectorAll(".snipsidian-preview-table").length,
+        ).toBe(1);
+    });
+
+    it("'Keep all current' sets every <select>.value to 'keep' without re-rendering", () => {
+        const modal = mount(makeDiff(2));
+
+        // Flip one to overwrite manually so the "keep all" action has
+        // something to undo.
+        const selects = modal.contentEl.querySelectorAll<HTMLSelectElement>(
+            ".conflict-action select",
+        );
+        selects[0].value = "overwrite";
+        selects[0].dispatchEvent(new Event("change"));
+        expect(selects[0].value).toBe("overwrite");
+
+        const keepAll = Array.from(
+            modal.contentEl.querySelectorAll<HTMLButtonElement>(
+                ".snipsidian-bulk-actions button",
+            ),
+        ).find((b) => b.textContent === "Keep all current");
+        if (!keepAll) throw new Error("'Keep all current' button not found");
+        keepAll.click();
+
+        const selectsAfter = modal.contentEl.querySelectorAll<HTMLSelectElement>(
+            ".conflict-action select",
+        );
+        for (const s of selectsAfter) {
+            expect(s.value).toBe("keep");
+        }
+        // No DOM duplication.
+        expect(
+            modal.contentEl.querySelectorAll(".modal-button-container").length,
+        ).toBe(1);
+    });
+
+    it("repeated bulk clicks do NOT accumulate DOM (regression for close+open bug)", () => {
+        const modal = mount(makeDiff(2));
+
+        const overwriteAll = Array.from(
+            modal.contentEl.querySelectorAll<HTMLButtonElement>(
+                ".snipsidian-bulk-actions button",
+            ),
+        ).find((b) => b.textContent === "Overwrite all")!;
+        const keepAll = Array.from(
+            modal.contentEl.querySelectorAll<HTMLButtonElement>(
+                ".snipsidian-bulk-actions button",
+            ),
+        ).find((b) => b.textContent === "Keep all current")!;
+
+        // Click bulk actions several times.
+        overwriteAll.click();
+        keepAll.click();
+        overwriteAll.click();
+        keepAll.click();
+
+        // Tables, button bars, and footers should all still be singleton.
+        expect(
+            modal.contentEl.querySelectorAll(".snipsidian-preview-table").length,
+        ).toBe(1);
+        expect(
+            modal.contentEl.querySelectorAll(".snipsidian-bulk-actions").length,
+        ).toBe(1);
+        expect(
+            modal.contentEl.querySelectorAll(".modal-button-container").length,
+        ).toBe(1);
+        // Final state: all "keep" (last click was Keep all).
+        for (const s of modal.contentEl.querySelectorAll<HTMLSelectElement>(
+            ".conflict-action select",
+        )) {
+            expect(s.value).toBe("keep");
+        }
+    });
+});


### PR DESCRIPTION
**Late-arriving 1.1.6 PR.** Discovered during smoke-testing the just-merged Reinstall flow (PR #39).

## Bug

\`PackagePreviewModal\`'s "Keep all current" / "Overwrite all" buttons implemented "update all conflict dropdowns" via \`this.close(); this.open();\` — a quick-and-dirty re-render trick. In the real Obsidian \`Modal\` lifecycle, \`close()\` doesn't synchronously empty \`contentEl\`, so the immediately-following \`open()\` ran \`onOpen\` against a still-populated container and appended a second copy of every block: summary line, conflicts table, bulk-actions bar, and footer (with its own Cancel + Apply). Every bulk click stacked another full copy.

User-visible behavior (screenshot in #39 review thread): clicking "Overwrite all" three times produced four copies of the summary + table + footer, vertically stacked, all inside the same modal frame.

The bug pre-dates 1.1.6, but only became user-visible after #39 (the Reinstall affordance from B-042). Pre-1.1.6 the disabled "Already installed" state hid the path that opens this modal — most users never saw the bulk actions. With the explicit Reinstall, this modal is now the standard reinstall flow.

## Fix

- Hold a reference to each conflict's \`<select>\` element during render (one push into a local array per row).
- \`setAll(choice)\` updates each select's \`.value\` and the corresponding entry in \`this.choices\` Map in place.
- "Keep all current" / "Overwrite all" call \`setAll("keep")\` / \`setAll("overwrite")\`. No close, no open, no re-render.

**Bonus** (a11y / B-091 cleanup): replaced the lingering \`new Setting(contentEl).setHeading().setName("Conflicts")\` with a real \`<h3>Conflicts</h3>\`. Rest of the codebase already moved to real headings in 1.1.0; this site was missed.

## Regression test

New \`src/ui/components/PackagePreviewModal.test.ts\` (3 cases, jsdom mount):

1. **"Overwrite all"** updates every \`<select>.value\` to \`"overwrite"\` AND keeps exactly one of each: conflicts table, bulk-actions bar, footer.
2. **"Keep all current"** symmetric — after a manual flip to "overwrite" on one row, click "Keep all current" → every select back to "keep", no DOM growth.
3. **Repeated bulk clicks (4× sequence)** still produce singletons of every block.

If anyone ever puts the \`close()+open()\` trick back, test #3 fails immediately.

## Test plan

- [x] \`npx tsc -p tsconfig.json --noEmit\` — clean
- [x] \`npm test\` — 350/350 (was 347; +3 from this PR)
- [x] \`npm run build\` — main.js 182.0kb
- [ ] Manual smoke: install pack → edit 2-3 rows → Reinstall → click "Overwrite all" → all dropdowns flip to Overwrite in place, no stacking → Apply works → settings updated as expected.
- [ ] CI green

## Risk

Low. Single-file UI change with a regression test against the previous failure mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)