### PR TITLE
fix(a11y): close B-003 umbrella tail — WCAG-relevant polish (1.1.7 PR 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **A11y: assistive-technology coverage of the Settings UI** (B-003 umbrella tail — closes B-084 / B-085 / B-087 / B-088 / B-090). Package-submission validation result now carries a `✓` / `✗` text prefix and `role="status"` / `role="alert"` alongside the existing colour tint, so users on monochrome schemes or with strong colour blindness get the same at-a-glance signal as everyone else. Three previously-unlabelled hand-built inputs (`JSONModal` textarea, `GroupPickerModal` new-group input, `EspansoSection` YAML paste) get explicit `aria-label`s; screen readers stop announcing them as "edit, blank". Five modals (`JSONModal`, `PackagePreviewModal`, `GroupPickerModal`, `AddSnippetModal`, the raw-`new Modal` package-details) now `.focus()` their primary input / primary action on open instead of leaving focus on the modal title. The bulk-bar count, the package-filter result count, and the validation-error text in `TextPromptModal` are now wrapped in `aria-live="polite"`; the package-Refresh button toggles `aria-busy="true"` while a reload is in flight. Custom-styled buttons (`.snipsy-tab`, `.snippet-action`) gain explicit `:focus-visible` outlines so keyboard users can see which one currently holds focus.
+
 ## [1.1.6] - 2026-05-21
 
 Install path correctness. Closes the P0 footgun where the disabled "Already installed" button after a user edit silently overwrote local changes on the next install click; replaces the dead-end with explicit Reinstall and Uninstall affordances. Refactors the install-plan logic out of UI handlers so the fix has a function-boundary test that pins the contract.

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -35,6 +35,22 @@
   margin: 0;
 }
 
+/* ---- Visually-hidden helper for aria-live regions ----
+   Standard pattern: keep the element in DOM (so AT can read it)
+   while removing it from sighted-user layout. Used for B-088
+   live-count announcements. */
+.snipsidian-settings .snipsy-visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 /* ---- Tabs (top of settings pane) ---- */
 .snipsidian-settings .snipsy-tabs {
   display: flex;
@@ -55,6 +71,14 @@
   margin-bottom: -1px;
 }
 .snipsidian-settings .snipsy-tab:hover { color: var(--snipsy-text); }
+/* B-090: explicit focus-visible ring — the tab overrides Obsidian's
+   default focus styles, so without this keyboard users couldn't
+   tell which tab held focus. */
+.snipsidian-settings .snipsy-tab:focus-visible {
+  outline: 2px solid var(--interactive-accent);
+  outline-offset: -2px;
+  border-radius: var(--snipsy-radius);
+}
 .snipsidian-settings .snipsy-tab.is-active {
   color: var(--snipsy-text);
   border-bottom-color: var(--snipsy-accent);
@@ -219,6 +243,13 @@
   cursor: pointer;
 }
 .snipsidian-settings .snippet-action:hover { background: var(--snipsy-hover); color: var(--snipsy-text); }
+/* B-090: explicit focus-visible ring — the action button overrides
+   Obsidian's default focus styles. Without this, keyboard users
+   couldn't tell which row's Edit / Delete had focus. */
+.snipsidian-settings .snippet-action:focus-visible {
+  outline: 2px solid var(--interactive-accent);
+  outline-offset: 2px;
+}
 .snipsidian-settings .snippet-action.is-danger:hover {
   background: var(--background-modifier-error-hover, rgba(255, 80, 80, 0.1));
   color: var(--snipsy-danger);

--- a/src/ui/components/Modals.ts
+++ b/src/ui/components/Modals.ts
@@ -36,6 +36,11 @@ export class JSONModal extends Modal {
 
         const close = footer.createEl("button", { text: "Close" });
         close.onclick = () => this.close();
+
+        // B-087: explicit focus on the textarea so screen-reader /
+        // keyboard users land somewhere meaningful instead of on the
+        // modal title (Obsidian's default).
+        ta.focus();
     }
 }
 
@@ -129,6 +134,11 @@ export class PackagePreviewModal extends Modal {
             }
             this.close();
         };
+
+        // B-087: focus Apply by default. Cancel is harmless (Escape
+        // also closes the modal), so the primary action is the right
+        // initial target for keyboard / screen-reader users.
+        apply.focus();
     }
 }
 
@@ -212,6 +222,11 @@ export class GroupPickerModal extends Modal {
             this.onSubmit?.(target);
             this.close();
         };
+
+        // B-087: focus the group <select> on open so keyboard users
+        // can immediately arrow-key through groups without first
+        // having to Tab past the modal title.
+        select.focus();
     }
 }
 
@@ -370,13 +385,18 @@ export class AddSnippetModal extends Modal {
         let trigger = "";
         let replacement = "";
         let group = "";
+        // Ref-object so TS doesn't narrow the field to `never` after
+        // the synchronously-invoked `addText` callback (control flow
+        // analysis can't prove the callback ran before later code).
+        const refs: { trigger?: HTMLInputElement } = {};
 
         new Setting(contentEl)
             .setName("Trigger")
             .setDesc("The text that will be expanded (e.g., :hello)")
             .addText((text) => {
+                refs.trigger = text.inputEl;
                 text
-                     
+
                     .setPlaceholder("Example: :hello")
                     .setValue(trigger)
                     .onChange((value) => {
@@ -450,6 +470,12 @@ export class AddSnippetModal extends Modal {
 
         const cancel = footer.createEl("button", { text: "Cancel" });
         cancel.onclick = () => this.close();
+
+        // B-087: focus the Trigger field on open so the user can
+        // start typing immediately. Skips Obsidian's default of
+        // putting focus on the modal frame, which screen readers
+        // announce as the modal title instead of the first input.
+        refs.trigger?.focus();
     }
 }
 

--- a/src/ui/components/Modals.ts
+++ b/src/ui/components/Modals.ts
@@ -21,7 +21,10 @@ export class JSONModal extends Modal {
         titleEl.setText(this.title);
 
         contentEl.addClass("snipsidian-modal");
-        const ta = contentEl.createEl("textarea", { text: this.text });
+        const ta = contentEl.createEl("textarea", {
+            text: this.text,
+            attr: { "aria-label": this.title },
+        });
         ta.addClass("snipsidian-json-input");
 
         const footer = contentEl.createDiv({ cls: "modal-button-container" });
@@ -171,6 +174,7 @@ export class GroupPickerModal extends Modal {
         const input = newWrap.createEl("input", {
             type: "text",
             placeholder: "New group name",
+            attr: { "aria-label": "New group name" },
         });
         const newErr = newWrap.createDiv({ cls: "snipsidian-error" });
         newErr.hide();

--- a/src/ui/components/Modals.ts
+++ b/src/ui/components/Modals.ts
@@ -264,8 +264,12 @@ export class TextPromptModal extends Modal {
                 t.inputEl.addEventListener("input", () => { this.value = t.getValue(); });
             });
 
-        // Error text
-        const err = contentEl.createDiv({ cls: "snipsidian-error" });
+        // Error text. B-088: aria-live="polite" so AT users hear
+        // validation errors as they appear without losing input focus.
+        const err = contentEl.createDiv({
+            cls: "snipsidian-error",
+            attr: { "aria-live": "polite" },
+        });
 
         // Footer
         const footer = contentEl.createDiv({ cls: "modal-button-container" });

--- a/src/ui/components/SnippetsTab.ts
+++ b/src/ui/components/SnippetsTab.ts
@@ -129,7 +129,14 @@ export class SnippetsTab {
     private renderBulkBar(root: HTMLElement) {
         // Sticky bar lives above the list. Hidden when nothing's selected
         // so it never wastes vertical space (designer Q3).
-        this.bulkBar = root.createDiv({ cls: "snipsy-bulk-bar is-hidden" });
+        //
+        // B-088: aria-live="polite" so AT users hear "3 selected" /
+        // "5 selected" announced as the count changes — without
+        // moving keyboard focus.
+        this.bulkBar = root.createDiv({
+            cls: "snipsy-bulk-bar is-hidden",
+            attr: { "aria-live": "polite", "aria-atomic": "true" },
+        });
     }
 
     private updateBulkBar() {

--- a/src/ui/components/community/EspansoSection.ts
+++ b/src/ui/components/community/EspansoSection.ts
@@ -31,6 +31,7 @@ export class EspansoSection {
     const espansoTextarea: HTMLTextAreaElement = espansoYamlContainer.createEl("textarea", {
       placeholder: "Paste Espanso YAML here…",
       cls: "yaml-textarea",
+      attr: { "aria-label": "Espanso YAML to import" },
     });
 
     const espansoButtonRow = espansoSection.createDiv({ cls: "button-row" });

--- a/src/ui/components/community/PackageBrowser.ts
+++ b/src/ui/components/community/PackageBrowser.ts
@@ -41,6 +41,8 @@ export class PackageBrowser {
     private state: "loading" | "ready" | "error" = "loading";
     private section: HTMLElement | null = null;
     private listEl: HTMLElement | null = null;
+    private refreshBtn: HTMLButtonElement | null = null;
+    private filterCountEl: HTMLSpanElement | null = null;
 
     constructor(
         private app: App,
@@ -80,8 +82,17 @@ export class PackageBrowser {
             text: "Refresh",
             attr: { type: "button", "aria-label": "Refresh packages from GitHub" },
         });
+        this.refreshBtn = refreshBtn;
         refreshBtn.addEventListener("click", () => {
             void this.refresh();
+        });
+
+        // B-088: visually-hidden aria-live region announcing the
+        // filtered count after every input. Sighted users see the
+        // list change; AT users get a polite announcement.
+        this.filterCountEl = toolbar.createSpan({
+            cls: "snipsy-visually-hidden",
+            attr: { "aria-live": "polite", "aria-atomic": "true" },
         });
 
         this.listEl = this.section.createDiv({ cls: "packages-list" });
@@ -92,6 +103,8 @@ export class PackageBrowser {
     private async load() {
         if (!this.listEl) return;
         this.state = "loading";
+        // B-088: announce loading state to AT.
+        this.refreshBtn?.setAttr("aria-busy", "true");
         this.renderSkeleton();
         try {
             const items = await loadAllCommunityPackages(this.app, this.plugin);
@@ -104,6 +117,8 @@ export class PackageBrowser {
             console.error("[snipsy] failed to load community packages", err);
             this.state = "error";
             this.renderError();
+        } finally {
+            this.refreshBtn?.removeAttribute("aria-busy");
         }
     }
 
@@ -160,6 +175,18 @@ export class PackageBrowser {
     private renderList() {
         if (!this.listEl) return;
         this.listEl.empty();
+
+        // B-088: announce filtered count to AT (visually-hidden live
+        // region). Only updates when there's an active filter; an
+        // empty query produces an empty announcement so AT doesn't
+        // get noisy on first render.
+        if (this.filterCountEl) {
+            this.filterCountEl.setText(
+                this.searchQuery
+                    ? `Showing ${this.filteredPackages.length} of ${this.packages.length} packages`
+                    : "",
+            );
+        }
 
         if (this.filteredPackages.length === 0) {
             const empty = this.listEl.createDiv({ cls: "snipsy-empty" });

--- a/src/ui/components/community/PackageBrowser.ts
+++ b/src/ui/components/community/PackageBrowser.ts
@@ -388,6 +388,9 @@ export class PackageBrowser {
             pkg.label,
             this.plugin.settings.snippets,
         );
+        // B-087: focusBtn holds the affordance that should grab focus
+        // on modal open. Primary action varies with install state.
+        let focusBtn: HTMLButtonElement | null = null;
         if (installed) {
             // B-042: same affordances as the row (Reinstall +
             // Uninstall) instead of a disabled "Installed" button.
@@ -407,6 +410,7 @@ export class PackageBrowser {
                 modal.close();
                 this.uninstallPackage(pkg);
             };
+            focusBtn = reinstallBtn;
         } else {
             const installBtn = footer.createEl("button", {
                 text: "Install",
@@ -417,10 +421,14 @@ export class PackageBrowser {
                 modal.close();
                 this.installPackage(pkg);
             };
+            focusBtn = installBtn;
         }
         footer.createEl("button", { text: "Close" }).onclick = () => modal.close();
 
         modal.open();
+        // B-087: focus the primary action so keyboard / AT users
+        // land on the install/reinstall entry point, not the title.
+        focusBtn?.focus();
     }
 
     /**

--- a/src/ui/components/community/PackageSubmissionSection.ts
+++ b/src/ui/components/community/PackageSubmissionSection.ts
@@ -136,9 +136,17 @@ export class PackageSubmissionSection {
         container.empty();
         submitBtn.disabled = !validation.isValid;
 
+        // B-084: textual marker on the title alongside the colour
+        // tint. Title text alone already carries state ("Package is
+        // valid" vs "Validation failed"), but for users on monochrome
+        // schemes or with strong colour blindness, the ✓ / ✗ prefix
+        // makes the success/failure read at a glance independent of
+        // hue. The `role="status"` (success) / `role="alert"`
+        // (failure) attributes wire the result into AT announcements.
         if (validation.isValid) {
             const ok = container.createDiv({ cls: "snipsy-submit-valid" });
-            ok.createDiv({ text: "Package is valid", cls: "snipsy-submit-title" });
+            ok.setAttr("role", "status");
+            ok.createDiv({ text: "✓ Package is valid", cls: "snipsy-submit-title" });
             if (validation.warnings.length > 0) {
                 const warnings = ok.createDiv({ cls: "snipsy-submit-warnings" });
                 warnings.createDiv({ text: "Warnings:", cls: "snipsy-submit-subtitle" });
@@ -148,7 +156,8 @@ export class PackageSubmissionSection {
             }
         } else {
             const err = container.createDiv({ cls: "snipsy-submit-invalid" });
-            err.createDiv({ text: "Validation failed", cls: "snipsy-submit-title" });
+            err.setAttr("role", "alert");
+            err.createDiv({ text: "✗ Validation failed", cls: "snipsy-submit-title" });
             validation.errors.forEach((e) =>
                 err.createDiv({ text: `• ${e}`, cls: "snipsy-submit-item" }),
             );

--- a/styles.css
+++ b/styles.css
@@ -78,6 +78,22 @@
   margin: 0;
 }
 
+/* ---- Visually-hidden helper for aria-live regions ----
+   Standard pattern: keep the element in DOM (so AT can read it)
+   while removing it from sighted-user layout. Used for B-088
+   live-count announcements. */
+.snipsidian-settings .snipsy-visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 /* ---- Tabs (top of settings pane) ---- */
 .snipsidian-settings .snipsy-tabs {
   display: flex;
@@ -98,6 +114,14 @@
   margin-bottom: -1px;
 }
 .snipsidian-settings .snipsy-tab:hover { color: var(--snipsy-text); }
+/* B-090: explicit focus-visible ring — the tab overrides Obsidian's
+   default focus styles, so without this keyboard users couldn't
+   tell which tab held focus. */
+.snipsidian-settings .snipsy-tab:focus-visible {
+  outline: 2px solid var(--interactive-accent);
+  outline-offset: -2px;
+  border-radius: var(--snipsy-radius);
+}
 .snipsidian-settings .snipsy-tab.is-active {
   color: var(--snipsy-text);
   border-bottom-color: var(--snipsy-accent);
@@ -262,6 +286,13 @@
   cursor: pointer;
 }
 .snipsidian-settings .snippet-action:hover { background: var(--snipsy-hover); color: var(--snipsy-text); }
+/* B-090: explicit focus-visible ring — the action button overrides
+   Obsidian's default focus styles. Without this, keyboard users
+   couldn't tell which row's Edit / Delete had focus. */
+.snipsidian-settings .snippet-action:focus-visible {
+  outline: 2px solid var(--interactive-accent);
+  outline-offset: 2px;
+}
 .snipsidian-settings .snippet-action.is-danger:hover {
   background: var(--background-modifier-error-hover, rgba(255, 80, 80, 0.1));
   color: var(--snipsy-danger);


### PR DESCRIPTION
**1.1.7 PR 1 of 4.** Plan: [`.claude/brain/sessions/2026-05-21-1.1.7-plan.md`](.claude/brain/sessions/2026-05-21-1.1.7-plan.md) (local-only).

## Summary

Closes the remaining assistive-technology coverage gaps from the 2026-05-14 [accessibility-specialist report](.claude/brain/reports/2026-05-14-accessibility-specialist.md). Five backlog items in one PR, six commits — each item is small in isolation but together they finish the B-003 umbrella.

### Items closed

| ID | Surface | Fix |
|---|---|---|
| **B-084** | `PackageSubmissionSection` validation result | `✓` / `✗` text prefix on title + `role="status"` / `role="alert"` on the container alongside the existing colour tint |
| **B-085** | `JSONModal` textarea, `GroupPickerModal` new-group input, `EspansoSection` YAML textarea | Explicit `aria-label` on each (screen readers stopped announcing "edit, blank") |
| **B-087** | `JSONModal`, `PackagePreviewModal`, `GroupPickerModal`, `AddSnippetModal`, `showPackageDetails` raw-`new Modal` | Explicit `.focus()` in `onOpen()` on the primary input / primary action so users don't land on the modal title |
| **B-088** | `SnippetsTab` bulk-bar, `PackageBrowser` filter count, `PackageBrowser` Refresh, `TextPromptModal` error div | `aria-live="polite"` + `aria-atomic="true"` on state-changing content; `aria-busy="true"` on Refresh during reload; new visually-hidden helper class |
| **B-090** | `.snipsy-tab`, `.snippet-action` | Explicit `:focus-visible` outline (2px `--interactive-accent`) — the original B-090 list of classes was retired in the 1.1.0 redesign |

### B-086 was already done

While auditing for this PR I confirmed `SnippetsTab` per-row + group select-all checkboxes already carry `aria-label="Select snippet ${triggerName}"` / `aria-label="Select all in group ${title}"` from an earlier change. Marking B-086 as done in the brain backlog without a commit here.

## Touch surface

- `src/ui/components/community/PackageSubmissionSection.ts` — validation result markers
- `src/ui/components/Modals.ts` — labels + focus + aria-live error
- `src/ui/components/SnippetsTab.ts` — bulk-bar aria-live
- `src/ui/components/community/PackageBrowser.ts` — filter count region + Refresh aria-busy + Package Details modal focus
- `src/ui/components/community/EspansoSection.ts` — textarea aria-label
- `src/styles/main.css` — `.snipsy-tab:focus-visible`, `.snippet-action:focus-visible`, `.snipsy-visually-hidden` helper
- `styles.css` — regenerated build artifact (lesson learned from 1.1.6: commit src + built CSS together)

## Test plan

- [x] \`npx tsc -p tsconfig.json --noEmit\` — clean
- [x] \`npm test\` — 350/350 (unchanged from main; behaviour-preserving)
- [x] \`npm run build\` — 182.7kb (+0.7kb from a11y attribute strings)
- [ ] Manual smoke: turn on VoiceOver (macOS) → navigate Settings → Snipsy → confirm each fix announces correctly
- [ ] Manual smoke: Tab-navigate through all surfaces → confirm a visible focus ring on every interactive element
- [ ] CI green

## Risk

Low. Every change is additive (new attributes / new CSS rules) — no logic touched. Each commit independently revertable if a specific surface regresses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)