### PR TITLE
perf(engine): cap findTrigger lookback at 64 chars (1.1.7 PR 4, B-019)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Performance
 
 - **Community-package fetch is parallel now** (B-024 / P-007). The Packages-tab cold-load used to fetch each `.yml` file sequentially — ~12× the latency of a single fetch with the current 12-pack catalog. Switched to `Promise.all` over the per-pack downloads; cold open of Packages drops from a couple of seconds to ~one fetch round trip. Each per-pack fetch still swallows its own errors, so one bad pack doesn't reject the whole batch.
+- **`findTrigger` lookback capped at 64 chars** (B-019). Without the cap, pathological inputs — a 50,000-char base64 paste, a long URL on one line, "log everything" files where a single line spans thousands of characters — caused `findTrigger` to walk all of it on every separator keystroke. 64 is well above any legitimate trigger length (current community-pack triggers max out at ~12 chars). Three boundary tests pin the cap. The other perf items (B-067 isInFencedCode caching, B-068 getDict memoise, B-070 picker regex cache) were investigated and deferred — see [ADR-0006](.claude/brain/decisions/0006-perf-hot-path-deferred.md).
 
 ### Internal
 

--- a/src/engine/match.test.ts
+++ b/src/engine/match.test.ts
@@ -151,4 +151,51 @@ describe("findTrigger", () => {
         expect(m?.fromCh).toBe(0);
         expect(m?.toCh).toBe("пр".length);
     });
+
+    it("[B-019] caps lookback at 64 chars — pathological non-separator runs return null", () => {
+        // 200-char run of non-separators (no spaces in the line up to
+        // the typed separator). Without the cap, findTrigger walks
+        // all 200 chars before concluding "no trigger". With the
+        // cap, it bails out after 64 chars. The dict is empty so
+        // even short matches return null — this test pins the
+        // null-bailout for pathological-length runs specifically.
+        const longRun = "a".repeat(200);
+        const input = {
+            textBefore: longRun,
+            textAfter: "",
+            lastTyped: " ",
+            sepCh: longRun.length,
+        };
+        expect(findTrigger(input, dict, delims)).toBeNull();
+    });
+
+    it("[B-019] triggers exactly 64 chars long still match (boundary)", () => {
+        const exactTrigger = "x".repeat(64);
+        const richDict = { ...dict, [exactTrigger]: "ok" };
+        const input = {
+            textBefore: exactTrigger,
+            textAfter: "",
+            lastTyped: " ",
+            sepCh: exactTrigger.length,
+        };
+        const m = findTrigger(input, richDict, delims);
+        expect(m?.trigger).toBe(exactTrigger);
+    });
+
+    it("[B-019] separator before the 64-char window is still found (short trigger after long URL)", () => {
+        // 200-char URL-like run + space + short trigger + separator
+        // → the short trigger is within the cap, finds the
+        // intermediate space and returns the short trigger.
+        const url = "h".repeat(200);
+        const trigger = "fn";
+        const before = `${url} ${trigger}`;
+        const input = {
+            textBefore: before,
+            textAfter: "",
+            lastTyped: " ",
+            sepCh: before.length,
+        };
+        const m = findTrigger(input, dict, delims);
+        expect(m?.trigger).toBe(trigger);
+    });
 });

--- a/src/engine/match.ts
+++ b/src/engine/match.ts
@@ -1,6 +1,26 @@
 import { DEFAULT_DELIMITERS, isSeparator } from "../shared/delimiters";
 import type { Dict, ExpandInput, TriggerMatch } from "./types";
 
+/**
+ * Maximum number of characters to walk back from a separator while
+ * looking for the trigger candidate. Real triggers are short (≤ 20
+ * chars typically — `markdown-essentials`/`obsidian-callouts` etc.).
+ * Beyond `MAX_LOOKBACK` we know there's no trigger here, and walking
+ * further is a per-separator-keystroke pathological cost:
+ *
+ *   - Paste a 50k-char base64 blob → without the cap, every
+ *     subsequent space in the same line scans 50k chars before
+ *     concluding "nope, no trigger".
+ *   - Long URLs in markdown source: same story.
+ *
+ * 64 is well clear of any legitimate trigger length. Increase if a
+ * trigger needs >64 chars (unlikely — engine would rebel before
+ * users want this).
+ *
+ * Closes B-019 (1.1.7).
+ */
+const MAX_LOOKBACK = 64;
+
 export function findTrigger(
   input: ExpandInput,
   dict: Dict,
@@ -10,9 +30,21 @@ export function findTrigger(
   if (!delimiters.includes(lastTyped)) return null;
 
   const line = textBefore + lastTyped;
-  let i = sepCh - 1;                  
+  let i = sepCh - 1;
+  // Lookback limit can be negative when sepCh < MAX_LOOKBACK — in
+  // that case the limit is effectively "off the start of the line",
+  // which the existing `i >= 0` check already handles.
+  const lookbackLimit = sepCh - 1 - MAX_LOOKBACK;
 
-  while (i >= 0 && !isSeparator(line[i] ?? "")) i--;
+  // Walk backwards. Three exit conditions:
+  //   1. `i < 0`        — reached the start of the line (valid, trigger starts at column 0)
+  //   2. separator      — found the boundary, trigger lives between here and sepCh
+  //   3. `i < lookbackLimit` — walked MAX_LOOKBACK chars without finding either (pathological run)
+  while (i >= 0 && i >= lookbackLimit && !isSeparator(line[i] ?? "")) i--;
+
+  // Case 3 only: we stopped INSIDE the line because of the lookback
+  // cap, not because of a separator. No real trigger could be that long.
+  if (i >= 0 && !isSeparator(line[i] ?? "")) return null;
 
   const fromCh = i + 1;
   const toCh = sepCh;


### PR DESCRIPTION
**1.1.7 PR 4 of 4 — last one before release.** Plan: \`.claude/brain/sessions/2026-05-21-1.1.7-plan.md\` (local-only). Reasoning behind the scope reduction: \`.claude/brain/decisions/0006-perf-hot-path-deferred.md\` (also local-only).

## Summary

The 1.1.7 plan's PR 4 was "Hot-path perf: measure first via B-073, then selective memoise from B-067/B-068/B-070". The measurement step happened — but by **reading the call sites carefully**, not by adding production-bound instrumentation.

**Conclusion:** only B-019 (the lookback cap on `findTrigger`) ships. The other three were investigated and deferred:

- **B-067** (`isInFencedCode` line-state cache): downgraded to "wait for signal". Real cost is <1ms on typical files (<2000 lines); the original "O(N) on every keystroke" framing was an overestimate because `tryExpandAtSeparator`'s `isSeparator(lastTyped)` gate means it only fires on separator keystrokes (~1/sec sustained).
- **B-068** (`getDict` memoise): deferred indefinitely. ~200μs per call at 50 snippets — not user-perceptible. Proper invalidation requires version-counter bumps at ~10 mutation sites or wrapping settings in setters; not worth the maintenance burden for microseconds.
- **B-070** (`SnippetPickerModal` regex cache): closed as based-on-outdated-code. The agent's "300 RegExp() per typed character" estimate was wrong — current `updatePreview()` only compiles regex for the SELECTED snippet (0-3 RegExp per render), not all 100 results.

Per the published article's "constraint, not ambition" philosophy: speculative perf without a user-complaint signal violates the maintenance-discipline thesis. ADR-0006 documents the reasoning for future-me.

## What ships: B-019 lookback cap

\`findTrigger\` walks backwards from the cursor looking for the trigger candidate. Without a cap, pathological inputs make every separator keystroke expensive:

- 50,000-char base64 paste → every space afterwards scans 50k chars
- Long URLs / data-URIs in markdown source
- "Log everything" files where one line spans thousands of chars

64 chars is well above any legitimate trigger length (current community-pack triggers max out around 12 chars). Past the cap, return null and skip the scan.

\`\`\`ts
const lookbackLimit = sepCh - 1 - MAX_LOOKBACK;
while (i >= 0 && i >= lookbackLimit && !isSeparator(line[i] ?? "")) i--;
if (i >= 0 && !isSeparator(line[i] ?? "")) return null;
\`\`\`

Three boundary tests:

1. 200-char run of non-separators → null (the win)
2. Exactly-64-char trigger still matches (the boundary)
3. Long URL + space + short trigger → finds the short trigger (cap doesn't break legitimate matches within the window)

All existing 365 tests still pass (column-0 triggers, multi-byte unicode, etc.).

## Test plan

- [x] \`npx tsc -p tsconfig.json --noEmit\` — clean
- [x] \`npm test\` — 368/368 (was 365 + 3 new B-019 tests)
- [x] \`npm run build\` — main.js 183.4kb (~unchanged)
- [ ] CI green

## Risk

Low. Single engine-layer change with the boundary specifically pinned by the tests. The hard part was getting the bailout logic right (the first attempt false-positive'd on column-0 triggers because the bailout check didn't distinguish "ran past lookback" from "hit start of line"). Fixed in the same commit, tests pin both behaviours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)