### PR TITLE
fix(ui): group accordion expands on full-header click, not just chevron (B-124)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Group accordion now expands when the title or count is clicked, not only the tiny chevron** (B-124). Latent since the original group-header layout — CSS had `cursor: pointer` on the whole `.group-header` (visually promising "I'm clickable") but the click handler was scoped to the 14×14 chevron button only. Users (correctly) tried to click the group title or the count badge and nothing happened. Reported by a user against 1.1.7 with the symptom "Group exists with 17 snippets but doesn't open" — the entire library was effectively inaccessible from the UI for anyone who didn't pixel-hunt for the chevron. Fix moves the click handler to the entire header div; the chevron stays as the AT-accessible affordance + visual rotate indicator (keyboard activation on the button bubbles to the header listener). Action buttons inside the header already had `stopPropagation()` so they don't double-toggle. 4 new regression tests cover: title click, count click, chevron click (keyboard activation path), and the rename-button-does-not-collapse invariant.
+
 ## [1.1.7] - 2026-05-21
 
 Quality pass. A11y umbrella (ARIA labels, focus rings, live regions) closed; `services/community-packages.ts` split into focused modules; install-plan-pattern extended from 1.1.6 to add/edit/delete snippet flows; community-packages fetch parallelised; `findTrigger` lookback capped against pathological lines; nine UX-polish bugs fixed across Espanso import, group rename, delete-group confirm, submit-popup-blocker, bulk-select flicker; the `src/ui/**` coverage exclusion lifted (coverage 88% → 95% lines on real-code). Two late additions: a B-118 mobile fix that stops a transient GitHub failure from pinning a blank Packages tab for 24h, and a scorecard regression-gate (`npm run scorecard:check`) wired into CI + `release:check`.

--- a/src/ui/components/SnippetsTab.test.ts
+++ b/src/ui/components/SnippetsTab.test.ts
@@ -248,3 +248,84 @@ describe("SnippetsTab — empty + filtered empty states", () => {
         expect(empty?.textContent).toContain("No snippets match your filter");
     });
 });
+
+// B-124 regression: pre-fix the click handler was only on the tiny
+// 14×14 chevron `.group-toggle` button. CSS had `cursor: pointer` on
+// the whole `.group-header`, which was lying — clicking the title text
+// or the count badge did nothing. Reported by a real user against
+// 1.1.7 ("Она не открывается" — clicked the title, expected expand,
+// nothing). Fix: click handler moved to the header div; chevron stays
+// as the AT-accessible affordance + visual indicator (no own click
+// handler — keyboard activation on the button bubbles to header).
+describe("SnippetsTab — group header click target (B-124)", () => {
+    it("expands the group when the title text is clicked, not just the chevron", () => {
+        mount({ hello: "world", brb: "be right back" });
+        const header = root.querySelector(".group-header") as HTMLElement;
+        expect(header).toBeTruthy();
+        const title = header.querySelector(".group-title") as HTMLElement;
+        expect(title?.textContent).toBe("Ungrouped");
+
+        // Body not yet rendered — group starts collapsed.
+        expect(root.querySelector(".group-content")).toBeNull();
+
+        // Click on the title text (NOT the chevron) — pre-fix this did
+        // nothing because the handler was scoped to `.group-toggle`.
+        // The click bubbles up to the header div which now owns the
+        // toggle behaviour.
+        title.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+
+        // Body now rendered with the two rows.
+        const content = root.querySelector(".group-content");
+        expect(content).toBeTruthy();
+        expect(content?.querySelectorAll(".snippet-row").length).toBe(2);
+    });
+
+    it("expands the group when the count badge is clicked too (whole header is the hit-target)", () => {
+        mount({ a: "1", b: "2", c: "3" });
+        const count = root.querySelector(".group-count") as HTMLElement;
+        expect(count?.textContent).toBe("3");
+
+        count.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+
+        expect(root.querySelectorAll(".snippet-row").length).toBe(3);
+    });
+
+    it("the chevron button still toggles via its bubbled click (keyboard activation path)", () => {
+        mount({ hello: "world" });
+        const toggle = root.querySelector(".group-toggle") as HTMLButtonElement;
+        // `.click()` on a button generates a click event that bubbles
+        // up to the header — same path the keyboard activation
+        // (Enter / Space on the focused button) takes.
+        toggle.click();
+        expect(root.querySelector(".group-content")).toBeTruthy();
+    });
+
+    it("clicking the rename action does not toggle the group (stopPropagation contract preserved)", () => {
+        // Setup: group already open so we can verify rename doesn't
+        // accidentally COLLAPSE it via the header listener.
+        // After every click that triggers renderList() the DOM is
+        // rebuilt — re-query each time.
+        mount({ "alpha/a": "1", "alpha/b": "2" });
+
+        const findAlphaTitle = () =>
+            Array.from(root.querySelectorAll(".group-header")).find(
+                (h) => h.querySelector(".group-title")?.textContent === "Alpha",
+            )?.querySelector(".group-title") as HTMLElement | undefined;
+
+        // Open via title click first.
+        findAlphaTitle()!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+        expect(root.querySelectorAll(".snippet-row").length).toBe(2);
+
+        // Click the rename button — should NOT toggle the group closed.
+        // (It opens a modal; we don't assert on the modal here, just on
+        // the toggle invariant: rows still rendered after the click.)
+        const renameBtn = root.querySelector(
+            '[aria-label^="Rename group Alpha"]',
+        ) as HTMLButtonElement;
+        renameBtn.click();
+
+        // Group still open (renameBtn fires stopPropagation, so the
+        // header click handler never sees the event).
+        expect(root.querySelectorAll(".snippet-row").length).toBe(2);
+    });
+});

--- a/src/ui/components/SnippetsTab.ts
+++ b/src/ui/components/SnippetsTab.ts
@@ -293,8 +293,25 @@ export class SnippetsTab {
         const groupEl = this.listEl.createDiv({ cls: "snippet-group" });
         const header = groupEl.createDiv({ cls: "group-header" });
 
-        // Chevron toggle. setIcon renders an SVG; we toggle the
-        // `.open` class to rotate it 90° via CSS (no glyph swap).
+        // B-124: click handler is on the entire header, not only on
+        // the tiny chevron button. CSS has `cursor: pointer` on the
+        // header which had been lying about clickability for ages —
+        // users (correctly) tried to click the title text "Ungrouped"
+        // and nothing happened. The 14×14 chevron was the only
+        // hit-target. Action buttons inside the header still
+        // `stopPropagation()` so they don't double-toggle. Keyboard
+        // activation on the chevron button still works: Enter/Space
+        // generates a click on the button which bubbles to the header.
+        header.addEventListener("click", () => {
+            this.uiState.setGroupOpen(group, !isOpen);
+            this.renderList();
+        });
+
+        // Chevron is the AT-accessible affordance + visual indicator.
+        // setIcon renders an SVG; we toggle the `.open` class to
+        // rotate it 90° via CSS (no glyph swap). No own click handler —
+        // the header listener above handles toggle for both mouse and
+        // keyboard (button click event bubbles up).
         const toggle = header.createEl("button", {
             cls: `group-toggle${isOpen ? " open" : ""}`,
             attr: {
@@ -304,10 +321,6 @@ export class SnippetsTab {
             },
         });
         setIcon(toggle, "chevron-right");
-        toggle.addEventListener("click", () => {
-            this.uiState.setGroupOpen(group, !isOpen);
-            this.renderList();
-        });
 
         header.createSpan({ text: title, cls: "group-title" });
         header.createSpan({ text: `${items.length}`, cls: "group-count" });


### PR DESCRIPTION
## Why

Real user report against 1.1.7. Forum quote (translated): "The trigger fires and replacement works, but the list is empty. Group exists with 17 snippets but it doesn't open."

Reproduced. Root cause is **a latent bug since the original group-header layout** (commit d794a26 in early 1.0.x). The CSS has `cursor: pointer` on the whole `.group-header` div — *implying* the entire header is clickable. The click handler was scoped only to the 14×14 chevron button. Action buttons inside the header (rename / delete) already had `stopPropagation()` — defensive code that only makes sense if a header-wide click was the original intent. The implementation just never wired the header listener.

Pre-fix: the ONLY way to expand a group via mouse was a 14-pixel hit-target on the chevron. Title click, count-badge click, header whitespace click — all silently did nothing. Users reasonably concluded the plugin was broken.

The same bug almost certainly explains an earlier user comment we'd dismissed as "didn't find the Snippets tab" — they probably found it, but couldn't open the group.

## What

- Move the click listener from `toggle.addEventListener` to `header.addEventListener`. Whole header is now the hit-target.
- Chevron stays as AT-accessible affordance (`aria-expanded` + `aria-label`) and visual indicator (`.open` rotates 90° via CSS). No own click handler — keyboard activation on the button generates a click event that bubbles up, so keyboard users keep their workflow.
- Action buttons keep their `stopPropagation()` — clicking rename / delete doesn't double-toggle.

## Test plan

- [x] `npm test` — 420/420 pass (4 new regression tests in `SnippetsTab.test.ts`)
- [x] `npm run scorecard:check` — 0 issues
- [x] `npm run release:check` — full gate green
- [x] Coverage: 95.29% lines / 90.39% branches
- [ ] Manual: open Settings → Snipsy → Snippets → click on "Ungrouped" title → group expands (was: nothing happens)
- [ ] Manual keyboard: Tab to chevron → press Enter → group expands
- [ ] Manual: rename / delete actions inside header still work without toggling

## Regression tests

`SnippetsTab — group header click target (B-124)` covers:

1. Title click expands the group (the original user-reported path)
2. Count-badge click expands the group (whole header is the hit-target)
3. Chevron-via-bubble click expands the group (keyboard activation path)
4. Rename action does NOT collapse the group (`stopPropagation` contract preserved)

## Followup

Need to ship 1.1.8 quickly — this affects every user who has at least one snippet without a group prefix (i.e. anyone who hit "Add snippet" without typing a group). Will respond to the reporting user once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)