### PR TITLE
docs: sync README and wiki with 1.2.0 (defaults group, privacy claims, Espanso labels)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,9 @@ Snipsy ships with these triggers ready to use. Type the trigger followed by a sp
 | **Dynamic** | `today` → today's date · `now` → current time |
 | **Conversational** | `brb` → `be right back` · `omw` → `on my way` · `ty` → `thank you` |
 
-Want more? Browse the **community catalog** in **Settings → Snipsy → Packages** — 10 starter packs cover Markdown essentials, daily journaling, GTD, meetings, dev boilerplate, code review, research notes, symbols & math, date stamps. Or paste any Espanso `.yml` from [hub.espanso.org](https://hub.espanso.org/) into the **Espanso import** section.
+On a fresh install these live in a single **Defaults** group in **Settings → Snipsy → Snippets**. Don't want them? Delete the group and they stay gone. Changed your mind? **Settings → Snipsy → General → Restore default snippets** brings back the missing ones without touching anything you added.
+
+Want more? Browse the **community catalog** in **Settings → Snipsy → Packages** — 10 starter packs cover Markdown essentials, daily journaling, GTD, meetings, dev boilerplate, code review, research notes, symbols & math, date stamps. Or paste any Espanso `.yml` from [hub.espanso.org](https://hub.espanso.org/) into the **Import from Espanso YAML** section.
 
 ---
 
@@ -114,7 +116,7 @@ Snipsy has two ways to get pre-made snippets:
 - **Obsidian Callouts** — `>note`, `>tip`, `>warning`, `>danger`, etc.
 - **Basic Emojis** — common emoji shortcuts (`smile` → 😀, `fire` → 🔥, etc.)
 
-**Espanso import.** Most Espanso packages are plain YAML. Copy the YAML from any package on [Espanso Hub](https://hub.espanso.org/), paste it into **Espanso import**, click Install. Conflicts open a preview so you can resolve them before anything writes to disk.
+**Espanso import.** Most Espanso packages are plain YAML. Copy the YAML from any package on [Espanso Hub](https://hub.espanso.org/), paste it into **Import from Espanso YAML** (Packages tab), pick a group name, click **Import snippets**. Imports land in that named group, so a whole import can be removed later by deleting the group. Conflicts open a preview so you can resolve them before anything writes to disk.
 
 ---
 
@@ -123,8 +125,9 @@ Snipsy has two ways to get pre-made snippets:
 Snipsy is offline-first.
 
 - Reads/writes only `.obsidian/plugins/snipsidian/data.json` in your vault.
-- Network: a single request to `api.github.com` when you open the Community packages tab (to list the catalog). No analytics, no telemetry, no account.
-- Optional submission flow uses a Google Form (your choice to fill it in).
+- Network: only when you use the Packages tab - `api.github.com` to list the catalog, `raw.githubusercontent.com` to download a pack you install. No analytics, no telemetry, no account.
+- Clipboard: a snippet whose replacement contains `$clipboard` reads your clipboard at the moment it expands (that's the feature). No snippet ships with `$clipboard` by default; check the install preview when adding third-party packs.
+- Package submission opens a prefilled GitHub issue in your browser - nothing is sent until you submit it there yourself.
 
 ---
 

--- a/docs/wiki/Troubleshooting.md
+++ b/docs/wiki/Troubleshooting.md
@@ -197,7 +197,7 @@ Common issues and solutions for Snipsy.
 - **Check data file** - Look at `.obsidian/plugins/snipsidian/data.json`
 - **Restore from backup** - Use your exported JSON backup
 - **Reinstall packages** - Reinstall any corrupted packages
-- **Reset to defaults** - Use "Add missing defaults" button
+- **Restore defaults** - Use **Settings → Snipsy → General → Restore default snippets** (re-adds missing built-in snippets; never overwrites yours)
 
 #### Sync Issues
 **Problem:** Snippets don't sync across devices.


### PR DESCRIPTION
Docs pass after the 1.2.0 release. Every claim is anchored to current code; no behavior changes.

## README

- **Try these out of the box**: new paragraph — defaults ship as a single deletable **Defaults** group on fresh installs, and **Settings → Snipsy → General → Restore default snippets** brings missing ones back (1.2.0 / B-131). Espanso section referenced by its real label.
- **Packages**: Espanso import described per the actual 1.1.7+ flow — **Import from Espanso YAML** / **Import snippets** labels (B-056/B-059/B-060 renames), named-group import (B-045) and group-delete as the uninstall path.
- **Privacy**: three corrections —
  - network claim now lists both hosts: `api.github.com` (catalog listing) and `raw.githubusercontent.com` (pack download on install);
  - new `$clipboard` disclosure: a snippet containing `$clipboard` reads the clipboard at expansion time (S-012 audit follow-up, "document, don't gate");
  - the stale "Google Form" submission claim (flow dropped in 1.1.0) replaced with the real prefilled-GitHub-issue flow.

## Wiki

- **Troubleshooting**: the 1.0.0-era "Add missing defaults" button never existed; replaced with the real **Restore default snippets** path.

Code anchors: `src/store/presets.ts`, `BasicTab.restoreDefaults`, `EspansoSection.ts`, `src/engine/placeholders.ts`, `services/community-api.ts`, `services/github-issue-url.ts`.

Note: `docs/wiki/` is wiki *source* — the GitHub Wiki page needs a manual sync after merge.